### PR TITLE
Relicense from MIT to PolyForm Noncommercial 1.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing to genesys-mcp
+
+Thanks for your interest in contributing. PRs, bug reports, and ideas are all welcome.
+
+Before you open a pull request, please read this page — by contributing you
+agree to the two things below: the **Developer Certificate of Origin** (proving
+you have the right to submit the code) and a **contribution licence grant**
+(letting the maintainer keep this project dual-licensed).
+
+## Licence context
+
+This project is **source-available, not open source**. It is licensed to the
+public under the [PolyForm Noncommercial License 1.0.0](LICENSE): free for
+noncommercial use, with **commercial use requiring a separate licence** from the
+maintainer. To be able to offer those commercial licences, the maintainer needs
+the right to license contributions under terms other than PolyForm Noncommercial
+— which is what the grant below provides.
+
+## 1. Sign off every commit (DCO)
+
+We use the [Developer Certificate of Origin](DCO) (DCO 1.1) — the same
+lightweight mechanism the Linux kernel uses. It is **not** a copyright
+assignment; you keep ownership of your work. Signing off simply certifies that
+you wrote the contribution (or otherwise have the right to submit it).
+
+Add a `Signed-off-by` line to every commit by committing with `-s`:
+
+```bash
+git commit -s -m "Your message"
+```
+
+This appends a line using your real name and the email in your Git config:
+
+```
+Signed-off-by: Jane Doe <jane@example.com>
+```
+
+By adding that line you certify the full text of the [DCO](DCO) for that
+contribution. Commits without a sign-off cannot be merged.
+
+## 2. Contribution licence grant
+
+In addition to the DCO, **by submitting a contribution to this project you grant
+Lawrence Drayton (the project maintainer and licensor) a perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable licence** to reproduce, modify, adapt,
+publish, distribute, sublicense, and otherwise use your contribution, **and to
+license your contribution to others under any terms** — including the PolyForm
+Noncommercial License, other open-source or source-available licences, and
+separate paid commercial licences — **at the maintainer's discretion**.
+
+You retain copyright in your contribution. This grant only ensures the
+maintainer can include your contribution in every version of the project,
+including commercially licensed ones, without having to track you down for
+permission later.
+
+You also represent that each contribution is your original work (or that you
+have the necessary rights to submit it under these terms) and that, to your
+knowledge, it does not infringe anyone else's rights.
+
+**Opening a pull request with a signed-off commit constitutes your agreement to
+both the DCO and this contribution licence grant.** If you are contributing on
+behalf of an employer, make sure you have authority to do so.
+
+## Practical notes
+
+- Keep PRs focused; one logical change per PR is easiest to review.
+- The roadmap in the [README](README.md#contributing) lists good starter areas.
+- If you are unsure whether a change fits the project's read-only-by-design
+  posture, open an issue first to discuss it.
+
+Questions about contributing — or about a **commercial licence** — are welcome
+via a GitHub issue or by email to <designsbylwd@gmail.com>.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,75 @@
-MIT License
+# Polyform Noncommercial License 1.0.0
 
-Copyright (c) 2026 Lawrence Drayton
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Required Notice: Copyright © 2026 Lawrence Drayton (https://github.com/laggyzee/genesys-mcp)
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+## Acceptance
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -374,7 +374,9 @@ Pair with the [`platform-api`](https://github.com/MakingChatbots/genesys-cloud-s
 
 ## Contributing
 
-PRs welcome. Things on the roadmap that someone might want to take a swing at:
+PRs welcome — please read [`CONTRIBUTING.md`](CONTRIBUTING.md) first. In short: sign off your commits under the [DCO](DCO) (`git commit -s`), and note that contributing also grants the maintainer the right to license your contribution under the project's commercial licence (so the project can stay dual-licensed). You keep copyright in your work.
+
+Things on the roadmap that someone might want to take a swing at:
 - Web messaging transcript wrapper (the `/api/v2/conversations/messages/{id}/messages/bulk` flow, which currently needs the `call_genesys_api` escape hatch)
 - Half-hourly intra-day staffing in `wfm_schedule` (currently rolls up to daily; the v0.9 hour-of-day heatmap covers the *demand* side, but scheduled-capacity bucketing is still daily)
 - Skill-based routing analysis (which agents have which skills × queue requirements)
@@ -384,4 +386,11 @@ Explicitly removed from the backlog: **outbound campaign coverage** (deferred ac
 
 ## Licence
 
-MIT — see `LICENSE`.
+**Source-available, not open source.** This project is licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE) — see [`LICENSE`](LICENSE).
+
+- **Noncommercial use is free.** Personal projects, research, evaluation, education, and use by nonprofits, public-research, and government bodies are all permitted at no cost.
+- **Commercial use requires a separate licence.** You may not use this software — or build a product or service on it — for commercial advantage or monetary compensation without a commercial licence from the maintainer. This includes selling it, offering it as a hosted/managed service, or bundling it into a commercial offering.
+
+**Commercial licensing:** email <designsbylwd@gmail.com>, or open a GitHub issue labelled `commercial-license` to start a conversation.
+
+**History:** all releases published before this licence change were under the MIT Licence and remain available under MIT for those versions — MIT rights already granted cannot be revoked. This and all future versions are licensed under PolyForm Noncommercial 1.0.0.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## v1.9.0 — 24 June 2026
+
+**Relicensed: MIT → PolyForm Noncommercial 1.0.0.** The project moves to a source-available, dual-licensed model. Noncommercial use — personal projects, research, evaluation, education, and use by nonprofits/public-research/government — remains free. **Commercial use now requires a separate licence from the maintainer**, including building a product or service on the MCP or offering it as a hosted/managed service.
+
+No functional changes: the tool surface, behaviour, and read-only-by-design posture are identical to v1.8.0.
+
+### Licence
+- `LICENSE` is now PolyForm Noncommercial 1.0.0.
+- Releases up to and including **v1.8.0 remain available under MIT** — rights already granted are not revoked. v1.9.0 and later are under PolyForm Noncommercial 1.0.0.
+- Commercial licensing enquiries: <designsbylwd@gmail.com>, or open a GitHub issue labelled `commercial-license`.
+
+### Contributing
+- New `CONTRIBUTING.md` and `DCO`. Contributions now require a Developer Certificate of Origin sign-off (`git commit -s`) **plus a contribution licence grant**, so contributions can be included in commercially licensed versions while contributors keep their copyright.
+
 ## v1.8.0 — 24 June 2026
 
 **Conversation attribute search + NPS auto-detection.** Closes a reporting gap surfaced by *"can you tell me what the NPS is today?"* and *"how many conversations had outcome = Resolved?"* Pre-v1.8 the MCP had **zero** path to question conversations by participant attribute — `search_conversations` only filtered by ANI / queue / agent / direction, and the async-jobs predicate dimensions don't target `participants[].attributes`. The dedicated Genesys "search by participant attribute" endpoint was completely unwrapped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,10 @@ name = "genesys-mcp"
 version = "1.8.0"
 description = "Local stdio MCP server exposing read-only Genesys Cloud access to Claude Code and other MCP clients"
 requires-python = ">=3.11"
+license = { file = "LICENSE" }
+classifiers = [
+    "License :: Other/Proprietary License",
+]
 dependencies = [
     "mcp[cli]>=1.8",
     "PureCloudPlatformClientV2>=220",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genesys-mcp"
-version = "1.8.0"
+version = "1.9.0"
 description = "Local stdio MCP server exposing read-only Genesys Cloud access to Claude Code and other MCP clients"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -216,7 +216,7 @@ wheels = [
 
 [[package]]
 name = "genesys-mcp"
-version = "1.7.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Switches the project from MIT to a **source-available, dual-licensed** model.

## What changes
- **LICENSE** → PolyForm Noncommercial 1.0.0. Noncommercial use stays free; commercial use — including building a product/service on it or offering it as a hosted service — now requires a separate licence from the maintainer.
- **CONTRIBUTING.md** (new) → DCO 1.1 sign-off **plus a contribution licence grant**, so contributions can be included in commercially licensed versions while contributors keep their copyright. (A plain DCO alone wouldn't allow this.)
- **DCO** (new) → verbatim Developer Certificate of Origin 1.1.
- **README** → rewritten Licence section (commercial contact: designsbylwd@gmail.com) and updated Contributing section pointing at the DCO + grant.
- **pyproject.toml** → `license` metadata points at `LICENSE`; adds `License :: Other/Proprietary License` classifier.

## Notes
- Releases up to and including **v1.8.0 remain available under MIT** — rights already granted can't be revoked. This and future versions are under PolyForm Noncommercial 1.0.0.
- Verified the wheel still builds and the license metadata resolves correctly.
- Follow-ups (not in this PR): create a `commercial-license` GitHub label; bump to **v1.9.0** on the next release for a crisp MIT→PolyForm boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)