### PR TITLE
v1.16.0: customer-first callback correctness (callback_outcomes tool + media-aware derived block)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,27 @@
 # Release Notes
 
+## v1.16.0 — 14 July 2026
+
+**Customer-first callback correctness.** On tenants using customer-first callbacks (the system dials the customer, detects a live answer, then bridges an agent), every aggregate-based view of callback media was structurally wrong: the callback ACD session ends the instant dial-out starts, so `tAnswered`/`tAbandon` never populate, `nConnected` is meaningless (live tenant: 7 "connected" out of 143 scheduled in a week where conversation-level classification shows ~86% of customers were actually reached), and the real outcome — the dial-out, the agent answer, the talk time — is booked on the queue's **voice** row. Consumers reading `derived.answered_pct` on callback rows were reporting "~98% of callbacks not connected" for queues whose callbacks were overwhelmingly succeeding.
+
+### New tool
+
+- **`callback_outcomes`** — the correct way to measure customer-first callbacks. Classifies each callback conversation's detail record (paginated `analytics/conversations/details` query, up to 2,000 conversations per call with an explicit `truncated` flag) into a funnel: `answered_and_bridged` / `answered_not_bridged` (customer answered, dropped before an agent joined) / `dialed_not_answered` / `never_dialed`. Returns per-queue and total: scheduled count, customer-reached count/%, bridged-to-agent count/%, avg wait-to-dial seconds, a dial-attempts (retry) histogram, and up to 3 example conversation ids per outcome for `get_conversation` drill-downs. Classification details pinned by tests against live-verified session shapes: bridged = an agent session carrying `tTalk` whose interact starts at/after the first dial-out (so an agent leg from the original inbound call that scheduled the callback can't false-positive), reached = an `interact` segment on the outbound customer voice session, and queue attribution comes from the callback ACD segment's own `queueId` (the details-query segment filters can over-match across queues).
+
+### Fixed
+
+- **`queue_performance`** — the derived block is now media-aware. Callback rows no longer ship `answered: 0` / `answered_pct: 0.0` (which read as "0% of callbacks connected"); those fields are `null` on callback rows, alongside what IS valid there — `callbacks_scheduled` (= nOffered), `avg_wait_to_dial_s` (= tWait), and a `callback_note` pointing at `callback_outcomes`. Voice/message/email rows are byte-identical to v1.15. The v1.15 docstring's callback note claimed `nConnected` = "customer reached and bridged" — disproven against the live tenant and rewritten: aggregates cannot measure customer-first callbacks at all.
+- **Docstrings on `agent_performance`, `agent_coaching_pack`, `agent_utilization`** — each now states that per-agent callback rows are structurally ~0 under customer-first callbacks (the bridged call is a voice session, so callback work already sits inside voice answered/handle) and must not be read as "agents aren't doing callbacks". Numeric output shapes are unchanged — existing consumers keep parsing.
+
+### Interpretation caveats (documented in the tool)
+
+- "Customer reached" relies on Genesys live-answer detection; voicemail pickups can count as answered.
+- Bridged callbacks also appear in the queue's voice aggregates as an extra offered+answered interaction with ~0s speed of answer — don't double-count when reading voice rows alongside `callback_outcomes`, and expect voice ASA to skew slightly low on callback-heavy queues.
+
+### Tests
+
+- New `tests/test_callback_outcomes.py` (14 tests): classifier outcomes incl. retry counting, pre-dial agent-leg exclusion, cross-queue over-match filtering; funnel math; callback-aware derived block (callback nulls, voice unchanged, ungrouped legacy shape); end-to-end pagination through the FastMCP tool surface with a mocked details endpoint.
+
 ## v1.15.0 — 9 July 2026
 
 **Endpoint-correctness pass.** A batch of fixes to request/response shapes that were verified against the Genesys Platform API schema and were silently wrong — wrong field routing, wrong field names, a call to an endpoint that doesn't exist, and a broken pagination style. None of these crashed outright; each one degraded a response (empty filters, truncated pages, false negatives) without raising, which is why they went unnoticed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genesys-mcp"
-version = "1.15.0"
+version = "1.16.0"
 description = "Local stdio MCP server exposing read-only Genesys Cloud access to Claude Code and other MCP clients"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }

--- a/src/genesys_mcp/server.py
+++ b/src/genesys_mcp/server.py
@@ -13,6 +13,7 @@ from genesys_mcp.client import assert_mcp_env_clean, init_api
 from genesys_mcp.tools import (
     analytics,
     attribute_search,
+    callbacks,
     coaching,
     conversations,
     directory,
@@ -74,6 +75,7 @@ wfm.register(mcp)
 quality.register(mcp)
 coaching.register(mcp)
 routing.register(mcp)
+callbacks.register(mcp)
 attribute_search.register(mcp)
 timeoff.register(mcp)
 utilization.register(mcp)

--- a/src/genesys_mcp/tools/analytics.py
+++ b/src/genesys_mcp/tools/analytics.py
@@ -100,8 +100,16 @@ def _attach_derived_metrics(resp: dict) -> None:
 
     nConnected in Genesys is not the same as 'answered' — the UI's 'Answer' column equals
     tAnswered.count. This helper computes the derived fields that ops users actually want.
+
+    Callback rows are special-cased: a customer-first callback's ACD session ends when
+    the dial-out starts, so tAnswered/tAbandon never populate on callback media — the
+    outcome is booked on the queue's voice row instead. Emitting answered_pct = 0 there
+    reads as "0% of callbacks connected", which is false; those fields are nulled and
+    the row carries what IS valid (scheduled count, wait-to-dial) plus a pointer to
+    the callback_outcomes tool.
     """
     for result in resp.get("results") or []:
+        media_type = (result.get("group") or {}).get("mediaType")
         for bucket in result.get("data") or []:
             stats = {m["metric"]: m.get("stats") or {} for m in bucket.get("metrics") or []}
             offered = stats.get("nOffered", {}).get("count", 0) or 0
@@ -118,6 +126,28 @@ def _attach_derived_metrics(resp: dict) -> None:
 
             def secs(s: float, c: float) -> float | None:
                 return round(s / c / 1000, 1) if c else None
+
+            if media_type == "callback":
+                bucket["derived"] = {
+                    "callbacks_scheduled": offered,
+                    "avg_wait_to_dial_s": secs(w_sum, w_cnt),
+                    "answered": None,
+                    "abandoned": None,
+                    "answered_pct": None,
+                    "abandoned_pct": None,
+                    "service_level_pct": None,
+                    "service_level_source": None,
+                    "service_level_unavailable_reason": "Service level does not apply to callback media.",
+                    "avg_wait_s": secs(w_sum, w_cnt),
+                    "avg_answer_s": None,
+                    "avg_handle_s": secs(h_sum, h_cnt),
+                    "callback_note": (
+                        "Customer-first callbacks record their outcome on this queue's voice "
+                        "row, so answered/abandoned are structurally empty here — nulls, not "
+                        "0%. Use the callback_outcomes tool for reached/bridged rates."
+                    ),
+                }
+                continue
 
             service_level_stats = stats.get("oServiceLevel", {})
             service_level_ratio = service_level_stats.get("ratio")
@@ -235,10 +265,15 @@ def register(mcp: FastMCP) -> None:
           - avg_answer_s   = tAnswered.sum / tAnswered.count / 1000  (ASA)
           - avg_handle_s   = tHandle.sum / tHandle.count / 1000
 
-        Callback media note: callbacks do not populate tAnswered/tAbandon. For callbacks,
-        nOffered = callbacks scheduled, nConnected = callbacks where customer was reached
-        and bridged to agent (customer-first flow). Derived answered/abandoned will be 0
-        on callback rows — treat nConnected / nOffered as the connect rate instead.
+        Callback media note (customer-first callbacks): a callback row only ever gets
+        nOffered (callbacks scheduled) and tWait (time until dial-out). The callback ACD
+        session ends the moment the system dials the customer, so tAnswered/tAbandon
+        never populate and nConnected is NOT a connect rate — do not derive callback
+        success from this tool at all. The dial-out, agent answer, and talk time are
+        booked on the queue's *voice* row (which therefore includes callback return
+        calls, answered in <1s). Derived answered/abandoned fields are null on callback
+        rows. For real callback outcomes (customer reached %, bridged-to-agent %, dial
+        attempts) use the callback_outcomes tool.
 
         Defaults to daily granularity, last 7 days, grouped by queue + media type.
         Use list_queues first to resolve queue ids.
@@ -399,6 +434,12 @@ def register(mcp: FastMCP) -> None:
         and groupBy=[userId, mediaType] for the auto-split. tAnswered.count is the
         canonical answered-conversation count (matches the UI's "Answer" column);
         tHandle.count matches the "Handle" column.
+
+        Callback media note: under customer-first callbacks agents never answer a
+        callback-media session — the bridged call is a voice session, so an agent's
+        callback work is already inside their VOICE answered/handle numbers and the
+        callback media row is ~0 for everyone. Do not report per-agent callback
+        counts from this tool; use callback_outcomes for queue-level callback rates.
         """
         api = gc.AnalyticsApi(get_api())
         resolved_interval = interval or _default_interval(7)

--- a/src/genesys_mcp/tools/callbacks.py
+++ b/src/genesys_mcp/tools/callbacks.py
@@ -1,0 +1,282 @@
+"""Callback outcome analysis: the customer-first callback funnel.
+
+Why this tool exists: with customer-first callbacks (the system dials the
+customer, detects a live answer, then bridges an agent) the callback media
+row in conversation *aggregates* is structurally empty — the callback ACD
+session ends the instant dial-out starts, so tAnswered/tAbandon never
+populate and nConnected is meaningless. The actual outcome (customer
+reached, agent bridged, talk time) is recorded on outbound voice sessions
+and a re-entry voice ACD leg. The only reliable way to measure callbacks is
+to classify each conversation's detail record, which is what this tool does.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from datetime import datetime
+from typing import Any
+
+import PureCloudPlatformClientV2 as gc
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from genesys_mcp._intervals import INTERVAL_HELP_STRING
+from genesys_mcp._intervals import default_interval as _default_interval
+from genesys_mcp._intervals import now_utc as _now_utc
+from genesys_mcp.client import get_api, to_dict, with_retry
+
+logger = logging.getLogger(__name__)
+
+_PAGE_SIZE = 100
+# Safety cap: 20 pages = 2,000 callback conversations per call. A day/week
+# window on a normal tenant is a few hundred at most; if the cap is hit the
+# response says so via `truncated` rather than silently under-reporting.
+_MAX_PAGES = 20
+
+OUTCOMES = (
+    "answered_and_bridged",
+    "answered_not_bridged",
+    "dialed_not_answered",
+    "never_dialed",
+)
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def classify_conversation(conv: dict, queue_ids: set[str] | None = None) -> dict | None:
+    """Classify one conversation's customer-first callback outcome.
+
+    Returns None when the conversation has no callback ACD segment on one of
+    the requested queues (the details-query segment filters can over-match:
+    each filter only needs to match *some* segment, not the same one).
+
+    Outcomes:
+      answered_and_bridged  — customer answered the dial-out and an agent
+                              interact (a session carrying tTalk) followed it
+      answered_not_bridged  — customer answered but hung up / dropped before
+                              any agent talk
+      dialed_not_answered   — dial-out placed but the customer never reached
+                              an interact segment (no answer / failed detect)
+      never_dialed          — callback created but no outbound dial found
+                              (expired, cancelled, or still pending)
+    """
+    callback_acd_starts: list[datetime] = []
+    callback_queue: str | None = None
+    dial_sessions: list[dict[str, list[dict]]] = []
+    agent_talk_starts: list[datetime] = []
+
+    for part in conv.get("participants") or []:
+        purpose = part.get("purpose")
+        for sess in part.get("sessions") or []:
+            media = sess.get("mediaType")
+            direction = sess.get("direction")
+            segments = sess.get("segments") or []
+            metric_names = {m.get("name") for m in (sess.get("metrics") or [])}
+
+            if purpose == "acd" and media == "callback":
+                for seg in segments:
+                    qid = seg.get("queueId")
+                    if queue_ids is not None and qid not in queue_ids:
+                        continue
+                    start = _parse_ts(seg.get("segmentStart"))
+                    if start:
+                        callback_acd_starts.append(start)
+                    if callback_queue is None:
+                        callback_queue = qid
+            elif purpose == "customer" and media == "voice" and direction == "outbound":
+                dial_sessions.append({
+                    "dialing": [s for s in segments if s.get("segmentType") == "dialing"],
+                    "interact": [s for s in segments if s.get("segmentType") == "interact"],
+                })
+            elif purpose == "agent" and media == "voice" and "tTalk" in metric_names:
+                for seg in segments:
+                    if seg.get("segmentType") == "interact":
+                        start = _parse_ts(seg.get("segmentStart"))
+                        if start:
+                            agent_talk_starts.append(start)
+
+    if not callback_acd_starts:
+        return None
+
+    callback_start = min(callback_acd_starts)
+    dial_attempts = sum(len(d["dialing"]) for d in dial_sessions)
+    dial_starts = [
+        ts for d in dial_sessions for s in d["dialing"]
+        if (ts := _parse_ts(s.get("segmentStart"))) is not None
+    ]
+    first_dial = min(dial_starts) if dial_starts else None
+    customer_answered = any(d["interact"] for d in dial_sessions)
+    # Only agent talk that begins at/after the dial-out counts as a bridged
+    # callback — an agent leg from the original inbound call (e.g. an agent
+    # who scheduled the callback mid-conversation) must not count.
+    bridged = (
+        any(ts >= first_dial for ts in agent_talk_starts) if first_dial else False
+    )
+
+    if not dial_sessions:
+        outcome = "never_dialed"
+    elif not customer_answered:
+        outcome = "dialed_not_answered"
+    elif bridged:
+        outcome = "answered_and_bridged"
+    else:
+        outcome = "answered_not_bridged"
+
+    wait_to_dial_s = (
+        round((first_dial - callback_start).total_seconds(), 1)
+        if first_dial and first_dial >= callback_start
+        else None
+    )
+    return {
+        "conversation_id": conv.get("conversationId"),
+        "queue_id": callback_queue,
+        "outcome": outcome,
+        "dial_attempts": dial_attempts,
+        "wait_to_dial_s": wait_to_dial_s,
+    }
+
+
+def summarise_outcomes(rows: list[dict]) -> dict[str, Any]:
+    """Reduce classified rows into per-queue funnels plus a total funnel."""
+
+    def _funnel(subset: list[dict]) -> dict[str, Any]:
+        counts = Counter(row["outcome"] for row in subset)
+        scheduled = len(subset)
+        reached = counts["answered_and_bridged"] + counts["answered_not_bridged"]
+        bridged = counts["answered_and_bridged"]
+        waits = [r["wait_to_dial_s"] for r in subset if r["wait_to_dial_s"] is not None]
+        attempts = Counter(r["dial_attempts"] for r in subset)
+
+        def pct(n: int) -> float | None:
+            return round(n / scheduled * 100, 1) if scheduled else None
+
+        examples: dict[str, list[str]] = {}
+        for row in subset:
+            ids = examples.setdefault(row["outcome"], [])
+            if len(ids) < 3 and row["conversation_id"]:
+                ids.append(row["conversation_id"])
+
+        return {
+            "callbacks_scheduled": scheduled,
+            "customer_reached": reached,
+            "customer_reached_pct": pct(reached),
+            "bridged_to_agent": bridged,
+            "bridged_to_agent_pct": pct(bridged),
+            "outcomes": {o: counts.get(o, 0) for o in OUTCOMES},
+            "avg_wait_to_dial_s": round(sum(waits) / len(waits), 1) if waits else None,
+            "dial_attempts_histogram": {str(k): v for k, v in sorted(attempts.items())},
+            "example_conversation_ids": examples,
+        }
+
+    by_queue: dict[str, list[dict]] = {}
+    for row in rows:
+        by_queue.setdefault(row["queue_id"] or "unknown", []).append(row)
+
+    return {
+        "totals": _funnel(rows),
+        "queues": {qid: _funnel(subset) for qid, subset in sorted(by_queue.items())},
+    }
+
+
+def register(mcp: FastMCP) -> None:
+    @mcp.tool()
+    def callback_outcomes(
+        queue_ids: list[str] = Field(
+            description="Queue ids to analyse (required). Use list_queues to resolve names.",
+        ),
+        interval: str | None = Field(
+            default=None,
+            description=INTERVAL_HELP_STRING,
+        ),
+    ) -> dict:
+        """True outcome funnel for customer-first callbacks, per queue.
+
+        Aggregate metrics CANNOT measure customer-first callbacks: the callback
+        media row only ever gets nOffered (scheduled) and tWait (time until
+        dial-out) — the dial result and agent talk are booked on voice sessions.
+        This tool classifies each callback conversation's detail record instead
+        and returns, per queue and in total:
+
+          - callbacks_scheduled     — callback ACD sessions created
+          - customer_reached (+pct) — dial-out answered by the customer
+          - bridged_to_agent (+pct) — customer answered AND an agent talked
+          - outcomes                — full split: answered_and_bridged /
+                                      answered_not_bridged (customer answered,
+                                      dropped before an agent joined) /
+                                      dialed_not_answered / never_dialed
+          - avg_wait_to_dial_s      — callback creation to first dial attempt
+          - dial_attempts_histogram — retries needed per callback
+          - example_conversation_ids — up to 3 per outcome, for get_conversation
+
+        Caveats: "customer answered" relies on Genesys answer detection, so
+        voicemail pickups can count as answered. Bridged callbacks also appear
+        in the queue's VOICE aggregates (an extra offered+answered interaction
+        with near-zero speed of answer) — do not double-count callbacks when
+        reading voice rows alongside this tool. never_dialed includes callbacks
+        still waiting to be processed at query time.
+
+        Scans up to 2,000 callback conversations per call; `truncated: true`
+        signals the interval had more (narrow the window and re-query).
+        """
+        api = gc.AnalyticsApi(get_api())
+        window = interval or _default_interval(7)
+        wanted = set(queue_ids)
+
+        rows: list[dict] = []
+        total_hits: int | None = None
+        scanned = 0
+        truncated = False
+        for page in range(1, _MAX_PAGES + 1):
+            body: dict[str, Any] = {
+                "interval": window,
+                "order": "asc",
+                "orderBy": "conversationStart",
+                "paging": {"pageSize": _PAGE_SIZE, "pageNumber": page},
+                # Two segment filters: each must match SOME segment of the
+                # conversation (not necessarily the same one) — the queueId
+                # over-match this allows is corrected in classify_conversation,
+                # which only accepts callback ACD segments on requested queues.
+                "segmentFilters": [
+                    {"type": "and", "predicates": [
+                        {"type": "dimension", "dimension": "mediaType", "operator": "matches", "value": "callback"},
+                    ]},
+                    {"type": "or", "predicates": [
+                        {"type": "dimension", "dimension": "queueId", "operator": "matches", "value": qid}
+                        for qid in queue_ids
+                    ]},
+                ],
+            }
+            resp = to_dict(with_retry(api.post_analytics_conversations_details_query)(body)) or {}
+            if total_hits is None:
+                total_hits = resp.get("totalHits")
+            conversations = resp.get("conversations") or []
+            scanned += len(conversations)
+            for conv in conversations:
+                row = classify_conversation(conv, wanted)
+                if row is not None:
+                    rows.append(row)
+            if len(conversations) < _PAGE_SIZE:
+                break
+        else:
+            truncated = True
+
+        out = summarise_outcomes(rows)
+        out["interval"] = window
+        out["conversations_scanned"] = scanned
+        out["total_hits"] = total_hits
+        out["truncated"] = truncated
+        out["caveats"] = [
+            "customer_reached relies on live-answer detection; voicemail pickups can count as answered.",
+            "Bridged callbacks also appear in the queue's voice aggregates (extra offered+answered, ~0s ASA).",
+            "never_dialed includes callbacks still queued for dial-out at query time.",
+        ]
+        out["as_of_utc"] = _now_utc().isoformat().replace("+00:00", "Z")
+        return out

--- a/src/genesys_mcp/tools/coaching.py
+++ b/src/genesys_mcp/tools/coaching.py
@@ -622,6 +622,11 @@ def register(mcp: FastMCP) -> None:
         QA section soft-fails (returns ``scope_available: false``) if the
         OAuth client lacks ``quality:readonly``; sentiment soft-fails on
         per-call STA 404s; the rest of the pack always populates.
+
+        Callback media note: under customer-first callbacks, ``callback_answered``
+        and ``callback_aht_s`` are structurally ~0/null for every agent — the
+        bridged call is a voice session, so callback work already sits inside the
+        agent's voice numbers. Never coach on the callback row.
         """
         # 1. Tenant config — required since v1.0 (pre-v1.0 silently fell
         # back to tenant-specific defaults). Errors propagate with a clear

--- a/src/genesys_mcp/tools/utilization.py
+++ b/src/genesys_mcp/tools/utilization.py
@@ -283,6 +283,11 @@ def register(mcp: FastMCP) -> None:
         all degrade to 0 with a top-level ``routing_status_scope_available:
         false`` flag, and the conversation-side answered counts still
         populate so the response is still partially useful.
+
+        Callback media note: under customer-first callbacks ``callback_answered``
+        is structurally ~0 for every agent — the bridged call is a voice session,
+        so callback work already sits inside voice answered/handle. Do not read
+        the callback column as "agents aren't doing callbacks".
         """
         if not user_ids:
             raise ValueError("user_ids must contain at least one id.")

--- a/tests/test_callback_outcomes.py
+++ b/tests/test_callback_outcomes.py
@@ -1,0 +1,284 @@
+"""callback_outcomes classification + funnel math, and the callback-aware derived block.
+
+Customer-first callbacks record their outcome on voice sessions (the callback ACD
+session ends at dial-out), so classification must walk conversation details. These
+tests pin the classifier against the session/segment shapes observed on a live
+tenant (2026-07): callback ACD session + outbound customer voice dial + re-entry
+agent voice session carrying tTalk.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from genesys_mcp.tools.analytics import _attach_derived_metrics
+from genesys_mcp.tools.callbacks import classify_conversation, summarise_outcomes
+
+QUEUE = "q-general"
+
+
+def _seg(seg_type: str, start: str, queue: str | None = None) -> dict:
+    seg = {"segmentType": seg_type, "segmentStart": start, "segmentEnd": start}
+    if queue:
+        seg["queueId"] = queue
+    return seg
+
+
+def _conv(
+    conv_id: str = "c1",
+    queue: str = QUEUE,
+    dial_attempts: int = 1,
+    customer_answered: bool = True,
+    agent_after_dial: bool = True,
+    agent_before_dial: bool = False,
+    with_dial: bool = True,
+) -> dict:
+    """Synthetic customer-first callback conversation.
+
+    Timeline mirrors live records: callback ACD at 08:45:41, dial at 08:5X:41,
+    customer interact 08:55:49, agent interact 08:56:31. agent_before_dial adds
+    an agent leg from the original inbound call (08:30) that must NOT count as
+    a bridged callback.
+    """
+    participants: list[dict] = [
+        {
+            "purpose": "acd",
+            "sessions": [{
+                "mediaType": "callback",
+                "direction": "outbound",
+                "segments": [_seg("interact", "2026-07-10T08:45:41.212Z", queue)],
+                "metrics": [{"name": "nOffered", "value": 1}],
+            }],
+        },
+    ]
+    if with_dial:
+        dialing = [
+            _seg("dialing", f"2026-07-10T08:5{i}:41.408Z", queue)
+            for i in range(dial_attempts)
+        ]
+        segments = list(dialing)
+        if customer_answered:
+            segments.append(_seg("interact", "2026-07-10T08:55:49.728Z", queue))
+        participants.append({
+            "purpose": "customer",
+            "sessions": [{
+                "mediaType": "voice",
+                "direction": "outbound",
+                "segments": segments,
+                "metrics": [],
+            }],
+        })
+    if agent_before_dial:
+        participants.append({
+            "purpose": "agent",
+            "sessions": [{
+                "mediaType": "voice",
+                "direction": "inbound",
+                "segments": [_seg("interact", "2026-07-10T08:30:00.000Z", queue)],
+                "metrics": [{"name": "tTalk", "value": 60000}],
+            }],
+        })
+    if agent_after_dial:
+        participants.append({
+            "purpose": "agent",
+            "sessions": [{
+                "mediaType": "voice",
+                "direction": "inbound",
+                "segments": [_seg("interact", "2026-07-10T08:56:31.000Z", queue)],
+                "metrics": [{"name": "tTalk", "value": 353135}],
+            }],
+        })
+    return {"conversationId": conv_id, "participants": participants}
+
+
+class TestClassifyConversation:
+    def test_answered_and_bridged(self):
+        row = classify_conversation(_conv())
+        assert row["outcome"] == "answered_and_bridged"
+        assert row["queue_id"] == QUEUE
+        assert row["dial_attempts"] == 1
+        assert row["wait_to_dial_s"] is not None
+
+    def test_answered_not_bridged(self):
+        row = classify_conversation(_conv(agent_after_dial=False))
+        assert row["outcome"] == "answered_not_bridged"
+
+    def test_dialed_not_answered(self):
+        row = classify_conversation(
+            _conv(customer_answered=False, agent_after_dial=False)
+        )
+        assert row["outcome"] == "dialed_not_answered"
+
+    def test_never_dialed(self):
+        row = classify_conversation(_conv(with_dial=False, agent_after_dial=False))
+        assert row["outcome"] == "never_dialed"
+        assert row["dial_attempts"] == 0
+
+    def test_retries_counted(self):
+        row = classify_conversation(_conv(dial_attempts=2))
+        assert row["dial_attempts"] == 2
+
+    def test_agent_leg_before_dial_does_not_count_as_bridged(self):
+        # An agent who took the original inbound call (and scheduled the
+        # callback) must not make an unbridged callback look bridged.
+        row = classify_conversation(
+            _conv(agent_after_dial=False, agent_before_dial=True)
+        )
+        assert row["outcome"] == "answered_not_bridged"
+
+    def test_non_callback_conversation_returns_none(self):
+        conv = {"conversationId": "x", "participants": [
+            {"purpose": "acd", "sessions": [{
+                "mediaType": "voice", "direction": "inbound",
+                "segments": [_seg("interact", "2026-07-10T08:00:00.000Z", QUEUE)],
+                "metrics": [],
+            }]},
+        ]}
+        assert classify_conversation(conv) is None
+
+    def test_queue_filter_excludes_other_queues(self):
+        # Segment filters over-match at the API level; the classifier must
+        # drop callbacks whose ACD segment sits on a non-requested queue.
+        assert classify_conversation(_conv(queue="q-other"), {QUEUE}) is None
+        assert classify_conversation(_conv(), {QUEUE}) is not None
+
+
+class TestSummariseOutcomes:
+    def test_funnel_math(self):
+        rows = [
+            classify_conversation(_conv(conv_id=f"b{i}")) for i in range(6)
+        ] + [
+            classify_conversation(_conv(conv_id="nb", agent_after_dial=False)),
+            classify_conversation(_conv(conv_id="na", customer_answered=False, agent_after_dial=False)),
+            classify_conversation(_conv(conv_id="nd", with_dial=False, agent_after_dial=False)),
+            classify_conversation(_conv(conv_id="r2", dial_attempts=2)),
+        ]
+        out = summarise_outcomes(rows)
+        totals = out["totals"]
+        assert totals["callbacks_scheduled"] == 10
+        assert totals["bridged_to_agent"] == 7            # 6 + the retry one
+        assert totals["customer_reached"] == 8            # bridged + not-bridged
+        assert totals["customer_reached_pct"] == 80.0
+        assert totals["bridged_to_agent_pct"] == 70.0
+        assert totals["outcomes"]["dialed_not_answered"] == 1
+        assert totals["outcomes"]["never_dialed"] == 1
+        assert totals["dial_attempts_histogram"]["2"] == 1
+        assert out["queues"][QUEUE]["callbacks_scheduled"] == 10
+        assert len(totals["example_conversation_ids"]["answered_and_bridged"]) == 3
+
+    def test_empty_rows(self):
+        out = summarise_outcomes([])
+        assert out["totals"]["callbacks_scheduled"] == 0
+        assert out["totals"]["customer_reached_pct"] is None
+        assert out["queues"] == {}
+
+
+class TestCallbackAwareDerivedBlock:
+    def _resp(self) -> dict:
+        return {"results": [
+            {
+                "group": {"queueId": "q1", "mediaType": "callback"},
+                "data": [{"interval": "i", "metrics": [
+                    {"metric": "nOffered", "stats": {"count": 143}},
+                    {"metric": "nConnected", "stats": {"count": 7}},
+                    {"metric": "tWait", "stats": {"count": 143, "sum": 55173891.0}},
+                ]}],
+            },
+            {
+                "group": {"queueId": "q1", "mediaType": "voice"},
+                "data": [{"interval": "i", "metrics": [
+                    {"metric": "nOffered", "stats": {"count": 100}},
+                    {"metric": "tAnswered", "stats": {"count": 90, "sum": 900000.0}},
+                    {"metric": "tAbandon", "stats": {"count": 5, "sum": 50000.0}},
+                ]}],
+            },
+        ]}
+
+    def test_callback_row_gets_nulls_not_zeros(self):
+        resp = self._resp()
+        _attach_derived_metrics(resp)
+        derived = resp["results"][0]["data"][0]["derived"]
+        assert derived["callbacks_scheduled"] == 143
+        assert derived["answered"] is None
+        assert derived["answered_pct"] is None
+        assert derived["abandoned_pct"] is None
+        assert derived["avg_wait_to_dial_s"] == 385.8
+        assert "callback_outcomes" in derived["callback_note"]
+
+    def test_voice_row_unchanged(self):
+        resp = self._resp()
+        _attach_derived_metrics(resp)
+        derived = resp["results"][1]["data"][0]["derived"]
+        assert derived["answered"] == 90
+        assert derived["answered_pct"] == 90.0
+        assert derived["abandoned_pct"] == 5.0
+        assert "callback_note" not in derived
+
+    def test_ungrouped_response_keeps_legacy_shape(self):
+        # group_by_media=False → no mediaType in group; must not special-case.
+        resp = {"results": [{
+            "group": {"queueId": "q1"},
+            "data": [{"interval": "i", "metrics": [
+                {"metric": "nOffered", "stats": {"count": 10}},
+                {"metric": "tAnswered", "stats": {"count": 8, "sum": 80000.0}},
+            ]}],
+        }]}
+        _attach_derived_metrics(resp)
+        assert resp["results"][0]["data"][0]["derived"]["answered"] == 8
+
+
+class TestCallbackOutcomesTool:
+    def test_paginates_and_summarises(self, monkeypatch):
+        import asyncio
+        import json
+
+        import PureCloudPlatformClientV2 as gc
+        from mcp.server.fastmcp import FastMCP
+
+        from genesys_mcp import client as gen_client
+        from genesys_mcp.tools import callbacks as callbacks_mod
+
+        # Page 1 full (100 conversations) → page 2 short → stop.
+        pages = {
+            1: {"totalHits": 105, "conversations": [
+                _conv(conv_id=f"p1-{i}") for i in range(100)
+            ]},
+            2: {"totalHits": 105, "conversations": [
+                _conv(conv_id=f"p2-{i}", agent_after_dial=False) for i in range(5)
+            ]},
+        }
+        captured_bodies: list[dict] = []
+
+        def fake_details(self, body, **kwargs):
+            captured_bodies.append(body)
+            return pages[body["paging"]["pageNumber"]]
+
+        monkeypatch.setattr(
+            gc.AnalyticsApi, "post_analytics_conversations_details_query", fake_details,
+        )
+        monkeypatch.setattr(gen_client, "_api_client", gc.ApiClient())
+        # The fake returns plain dicts; production passes SDK models through to_dict.
+        monkeypatch.setattr(callbacks_mod, "to_dict", lambda x: x)
+
+        test_mcp = FastMCP(name="t")
+        callbacks_mod.register(test_mcp)
+        contents = asyncio.run(test_mcp.call_tool("callback_outcomes", {
+            "queue_ids": [QUEUE],
+            "interval": "2026-07-05T14:00:00.000Z/2026-07-12T14:00:00.000Z",
+        }))
+        # FastMCP returns a list of content blocks; the tool's dict comes back
+        # as JSON text in the first block.
+        payload = json.loads(contents[0].text)
+
+        assert len(captured_bodies) == 2
+        assert captured_bodies[0]["segmentFilters"][0]["predicates"][0]["value"] == "callback"
+        totals = payload["totals"]
+        assert totals["callbacks_scheduled"] == 105
+        assert totals["bridged_to_agent"] == 100
+        assert totals["outcomes"]["answered_not_bridged"] == 5
+        assert payload["truncated"] is False
+        assert payload["total_hits"] == 105
+        assert payload["conversations_scanned"] == 105


### PR DESCRIPTION
## Problem
On tenants using customer-first callbacks, callback aggregate rows are structurally empty: the callback ACD session ends the instant dial-out starts, so tAnswered/tAbandon never populate and nConnected is meaningless (live: 7/143 in a week where conversation-level classification shows ~86% of customers reached, 63% bridged). `derived.answered_pct = 0` on callback rows was driving '~98% of callbacks not connected' warnings in downstream consumers. The v1.15 docstring advice (nConnected/nOffered as connect rate) was disproven against live data.

## Changes
- **New `callback_outcomes` tool** — paginated conversation-details classification into a funnel (answered_and_bridged / answered_not_bridged / dialed_not_answered / never_dialed) per queue + totals, with reach/bridge %, avg wait-to-dial, dial-attempt histogram, example conversation ids, truncated flag. Classifier logic validated against live tenant conversations before implementation.
- **queue_performance**: media-aware derived block — callback rows null answered/abandoned (not false 0%), carry callbacks_scheduled / avg_wait_to_dial_s / callback_note. Voice/message rows byte-identical.
- Corrected queue_performance callback docstring; added callback notes to agent_performance / agent_coaching_pack / agent_utilization (shapes unchanged).

## Tests
630 passed (14 new in tests/test_callback_outcomes.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)