### PR TITLE
v1.17.0: presence data-availability watermark

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## v1.17.0 — 14 July 2026
+
+**Presence data-availability watermark.** Genesys settles users/details (presence/routing) data asynchronously behind a `dataAvailabilityDate` watermark, and a detail query for any window extending past it returns **partial data with no error and no flag** — the async job succeeds and silently omits the not-yet-settled tail. This produced a wrong coaching brief: collected at 06:00 for the prior day, it read an agent's last recorded presence session as her "logout" (5:37pm) when she had actually worked into the evening — the watermark was ~10 hours behind the day's end, so her evening on-queue time simply didn't exist in the response. Her conversation stats (a separate, near-real-time pipeline) were complete, which is why only the presence-derived figures were wrong.
+
+### Fixed
+
+- **`presence_sessions`** and **`break_overrun_report`** now check the availability watermark (`GET /api/v2/analytics/users/details/jobs/availability`) up front and return three new top-level fields:
+  - `data_complete` — `true` when the interval is fully settled, `false` when the watermark is behind the interval end (data is partial), `null` when the watermark couldn't be read (fail-open).
+  - `data_available_until` — the settled watermark, ISO-Z.
+  - `data_availability_note` — a plain-language explanation when data is incomplete.
+
+  When `data_complete` is `false`, consumers must not treat the last returned session as the agent's logout, and must treat per-presence totals / overrun counts as lower bounds. The watermark lookup never blocks the data query — a failure degrades to `data_complete: null`.
+
+### Internal
+
+- New `genesys_mcp/_availability.py` (`presence_data_availability`) — shared, fail-open watermark helper used by both tools.
+
+### Tests
+
+- New `tests/test_availability.py` (4 tests): complete / incomplete (the Deanna incident: 07:12Z watermark vs a 14:00Z day-close) / endpoint-error / missing-field. Suite 634 passed.
+
 ## v1.16.0 — 14 July 2026
 
 **Customer-first callback correctness.** On tenants using customer-first callbacks (the system dials the customer, detects a live answer, then bridges an agent), every aggregate-based view of callback media was structurally wrong: the callback ACD session ends the instant dial-out starts, so `tAnswered`/`tAbandon` never populate, `nConnected` is meaningless (live tenant: 7 "connected" out of 143 scheduled in a week where conversation-level classification shows ~86% of customers were actually reached), and the real outcome — the dial-out, the agent answer, the talk time — is booked on the queue's **voice** row. Consumers reading `derived.answered_pct` on callback rows were reporting "~98% of callbacks not connected" for queues whose callbacks were overwhelmingly succeeding.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genesys-mcp"
-version = "1.16.0"
+version = "1.17.0"
 description = "Local stdio MCP server exposing read-only Genesys Cloud access to Claude Code and other MCP clients"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }

--- a/scripts/deploy_eh_functions.py
+++ b/scripts/deploy_eh_functions.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""scripts/deploy_eh_functions.py — deploy the two Employment Hero FUNCTION data actions.
+
+Genesys disabled Velocity #foreach, so the two actions that must RENAME EH's array
+fields can't be plain data actions — they're Genesys Cloud *Function* data actions
+(Node.js). This deploys them via the Platform API:
+
+  create draft (POST /integrations/actions/drafts)
+   -> request upload URL (POST .../draft/function/upload)
+   -> PUT the zip to the presigned URL
+   -> set function handler/runtime (PUT .../draft/function)
+   -> publish (POST .../draft/publish)
+
+The Node.js code lives in ~/genesys-eh-leave-balances/functions/{get_balance,get_agents}.js
+(each is zipped as index.js; handler = index.handler).
+
+ONE-TIME CONSOLE PREREQ (you do this first):
+  1. Admin > Integrations > Add > "Genesys Cloud Function Data Actions"; install it.
+  2. On that integration, add a credential the function can read. Easiest: a
+     "User Defined" credential with ONE field named `apiKey` = your EH/KeyPay API key.
+  3. Note the integration's ID (Admin > Integrations > the integration > ... or the URL).
+Then run this with --integration-id <id>.  (Different field name? pass --credential-field.)
+
+OAuth: same write client as the other scripts (GENESYS_WRITE_CLIENT_* in .env.write).
+Role needs: integrations:action:add, :edit, :view (and the function upload/publish are
+covered by :edit). Default is --dry-run; --confirm applies.
+
+    PY=~/code/genesys-mcp/.venv/bin/python
+    $PY scripts/deploy_eh_functions.py --integration-id <fnIntegrationId>            # dry-run
+    $PY scripts/deploy_eh_functions.py --integration-id <fnIntegrationId> --confirm  # deploy both
+    $PY scripts/deploy_eh_functions.py --integration-id <id> --confirm --only get_balance
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import logging
+import os
+import sys
+import time
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+import PureCloudPlatformClientV2 as gc
+from PureCloudPlatformClientV2.rest import ApiException
+
+from genesys_mcp.client import GenesysConfigError, init_named_api
+
+log = logging.getLogger("deploy_eh_functions")
+
+ENV_FILES = (
+    _REPO_ROOT / ".env.write",
+    _REPO_ROOT / ".env",
+    Path.home() / ".config" / "genesys-mcp.env",
+)
+FUNCTIONS_DIR = Path.home() / "genesys-eh-leave-balances" / "functions"
+
+
+def load_dotenv_files(paths) -> list[Path]:
+    loaded = []
+    for path in paths:
+        if not path.exists():
+            continue
+        for raw in path.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            k = k.strip()
+            if k and k not in os.environ:
+                os.environ[k] = v.strip().strip('"').strip("'")
+        loaded.append(path)
+    return loaded
+
+
+def call_api(api: gc.ApiClient, method: str, path: str, *, body: Any = None, query: dict | None = None) -> Any:
+    return api.call_api(
+        resource_path=path, method=method, query_params=query or {}, body=body,
+        header_params={"Accept": "application/json", "Content-Type": "application/json"},
+        auth_settings=["PureCloud OAuth"], response_type="object",
+    )
+
+
+def _err(exc: ApiException) -> str:
+    b = getattr(exc, "body", None)
+    if isinstance(b, (bytes, bytearray)):
+        b = b.decode("utf-8", "replace")
+    return str(b)[:2000] if b else ""
+
+
+ERROR_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#", "title": "ErrorBody", "type": "object",
+    "required": ["errorCode", "status", "userMessage"],
+    "properties": {
+        "errorCode": {"type": "string"}, "status": {"type": "integer"},
+        "userMessage": {"type": "string"}, "correlationId": {"type": ["string", "null"]},
+        "errors": {"type": "array", "items": {"type": "object"}},
+    }, "additionalProperties": True,
+}
+
+# ─── The two function actions ────────────────────────────────────────────────
+# request_template builds the JSON event passed to the function. ${credentials.FIELD}
+# is filled with --credential-field at runtime. The function returns {values|employees}.
+FUNCTIONS: dict[str, dict[str, Any]] = {
+    "get_balance": {
+        "name": "HRIS - Employment Hero - Get Balance",
+        "js": "get_balance.js",
+        "input_schema": {
+            "title": "Request", "type": "object",
+            "properties": {"employeeId": {"type": "string"}, "end": {"type": "string"}},
+            "additionalProperties": True,
+        },
+        "success_schema": {
+            "title": "Response", "type": "object", "required": ["values"],
+            "properties": {"values": {"type": "array", "items": {"type": "object", "properties": {
+                "timeOffType": {"type": "integer"}, "name": {"type": "string"},
+                "balance": {"type": "string"}, "units": {"type": "string"}, "end": {"type": "string"},
+            }}}},
+        },
+        "request_template": '{"employeeId": "${input.employeeId}", "end": "${input.end}", "apiKey": "${credentials.%CRED%}"}',
+    },
+    "get_agents": {
+        "name": "HRIS - Employment Hero - Get Agents",
+        "js": "get_agents.js",
+        "input_schema": {"title": "Request", "type": "object", "properties": {}, "additionalProperties": True},
+        "success_schema": {
+            "title": "Response", "type": "object", "required": ["employees"],
+            "properties": {"employees": {"type": "array", "items": {"type": "object",
+                "required": ["id", "workEmail"],
+                "properties": {"id": {"type": "string"}, "workEmail": {"type": "string"},
+                               "externalId": {"type": "string"}}}}},
+        },
+        "request_template": '{"apiKey": "${credentials.%CRED%}"}',
+    },
+    "to_sydney_date": {
+        "name": "To Sydney Date",
+        "js": "to_sydney_date.js",
+        "input_schema": {"title": "Request", "type": "object",
+                         "properties": {"value": {"type": "string"}}, "additionalProperties": True},
+        "success_schema": {"title": "Response", "type": "object", "required": ["date"],
+                           "properties": {"date": {"type": "string"}}},
+        # No EH call / credential needed — pure date conversion.
+        "request_template": '{"value": "${input.value}"}',
+    },
+    "eh_hr_create_leave": {
+        "name": "EH HR - Create Leave Request",
+        "js": "eh_hr_create_leave.js",
+        "input_schema": {"title": "Request", "type": "object",
+                         "required": ["employeeExternalId", "paidCategoryId", "fromDate"],
+                         "properties": {"employeeExternalId": {"type": "string"}, "paidCategoryId": {"type": "string"},
+                                        "fromDate": {"type": "string"}, "toDate": {"type": "string"},
+                                        "payableMinutesCsv": {"type": "string"}, "comment": {"type": "string"}},
+                         "additionalProperties": True},
+        "success_schema": {"title": "Response", "type": "object", "required": ["ok"],
+                           "properties": {"ok": {"type": "boolean"}, "createdIds": {"type": "string"},
+                                          "paidHours": {"type": "number"}, "unpaidHours": {"type": "number"},
+                                          "skipped": {"type": "string"}, "error": {"type": "string"}}},
+        # Deploy to the EH HR function integration (31178bdb), whose userDefined credential holds the 4 secret fields.
+        # orgId, datatableId, lwopCategoryId (EH "Leave Without Pay") are non-secret config literals.
+        "request_template": (
+            '{"gcClientId":"${credentials.gcClientId}","gcClientSecret":"${credentials.gcClientSecret}",'
+            '"ehClientId":"${credentials.ehClientId}","ehClientSecret":"${credentials.ehClientSecret}",'
+            '"datatableId":"db754cfc-2b80-4a1e-8be0-ccd92f3eff9b","orgId":"bb033ff2-b0c8-41a5-87b0-5a24f418ee7c",'
+            '"lwopCategoryId":"9fcdff47-745b-421c-a550-9910fbd11e52",'
+            '"employeeExternalId":"${input.employeeExternalId}","paidCategoryId":"${input.paidCategoryId}",'
+            '"fromDate":"${input.fromDate}","toDate":"${input.toDate}",'
+            '"payableMinutesCsv":"${input.payableMinutesCsv}","comment":"${input.comment}"}'
+        ),
+    },
+}
+
+
+def build_zip(js_path: Path) -> bytes:
+    """Zip the JS file as index.js (handler = index.handler)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("index.js", js_path.read_text())
+    return buf.getvalue()
+
+
+def cleanup_prior(api, integration_id: str, name: str) -> None:
+    """Delete any prior action/draft with this name on the function integration, so
+    re-runs (and the failed-publish orphan) don't accumulate. Best-effort."""
+    for path in ("/api/v2/integrations/actions/drafts", "/api/v2/integrations/actions"):
+        try:
+            resp = call_api(api, "GET", path, query={"pageSize": 200})
+        except ApiException:
+            continue
+        for a in (resp or {}).get("entities", []):
+            if a.get("name") != name or a.get("integrationId") not in (integration_id, None):
+                continue
+            aid = a.get("id")
+            try:
+                call_api(api, "DELETE", f"/api/v2/integrations/actions/{aid}")
+                log.info("cleanup: deleted prior %s (%s)", name, aid)
+            except ApiException:
+                try:
+                    call_api(api, "DELETE", f"/api/v2/integrations/actions/{aid}/draft")
+                    log.info("cleanup: deleted prior draft %s (%s)", name, aid)
+                except ApiException as e:
+                    log.warning("cleanup: couldn't delete %s (%s): %s", name, aid, e.status)
+
+
+def _wait_zip_applied(api, action_id: str, key: str, *, loops: int = 30, delay: int = 2) -> None:
+    """The uploaded zip is processed asynchronously; publish fails until it's applied."""
+    log.info("[%s] waiting for uploaded zip to be applied…", key)
+    for _ in range(loops):
+        fc = call_api(api, "GET", f"/api/v2/integrations/actions/{action_id}/draft/function")
+        z = fc.get("zip") or {}
+        status = (z.get("status") or "")
+        if status:
+            log.info("[%s]   zip status: %s", key, status)
+        low = status.lower()
+        if any(k in low for k in ("avail", "applied", "built", "ready", "success", "complete", "active", "done")):
+            return
+        if any(k in low for k in ("error", "fail", "invalid", "exception")):
+            raise RuntimeError(f"zip processing failed: {status} {z.get('errorMessage', '')}")
+        time.sleep(delay)
+    log.warning("[%s] zip status not confirmed applied after %ss — attempting publish anyway", key, loops * delay)
+
+
+def deploy_one(api, key, defn, *, integration_id, category, credential_field, runtime, timeout) -> str:
+    name = defn["name"]
+    cleanup_prior(api, integration_id, name)
+    req_template = defn["request_template"].replace("%CRED%", credential_field)
+    body = {
+        "name": name, "category": category, "integrationId": integration_id, "secure": False,
+        "contract": {
+            "input": {"inputSchema": defn["input_schema"]},
+            "output": {"successSchema": defn["success_schema"], "errorSchema": ERROR_SCHEMA},
+        },
+        "config": {
+            "request": {"requestType": "POST", "headers": {}, "requestTemplate": req_template},
+            # The function returns the payload object directly; Genesys stringifies the
+            # whole return into rawResult, so pass it straight through to the contract.
+            "response": {"translationMap": {}, "translationMapDefaults": {}, "successTemplate": "${rawResult}"},
+        },
+    }
+    log.info("[%s] creating draft action on integration %s…", key, integration_id)
+    draft = call_api(api, "POST", "/api/v2/integrations/actions/drafts", body=body)
+    action_id = draft["id"]
+    log.info("[%s] draft id %s (v%s)", key, action_id, draft.get("version"))
+
+    js_path = FUNCTIONS_DIR / defn["js"]
+    zip_bytes = build_zip(js_path)
+    log.info("[%s] requesting upload URL for index.zip (%d bytes)…", key, len(zip_bytes))
+    up = call_api(api, "POST", f"/api/v2/integrations/actions/{action_id}/draft/function/upload",
+                  body={"fileName": "index.zip", "signedUrlTimeoutSeconds": 600})
+    url, headers = up["url"], up.get("headers", {}) or {}
+    log.info("[%s] uploading zip (PUT presigned URL)…", key)
+    put = urllib.request.Request(url=url, data=zip_bytes, method="PUT", headers=headers)
+    with urllib.request.urlopen(put) as r:  # noqa: S310 (Genesys-signed S3 URL)
+        log.info("[%s] upload HTTP %s", key, r.status)
+
+    log.info("[%s] setting function (handler=index.handler runtime=%s timeout=%ss)…", key, runtime, timeout)
+    call_api(api, "PUT", f"/api/v2/integrations/actions/{action_id}/draft/function",
+             body={"handler": "index.handler", "runtime": runtime, "timeoutSeconds": timeout})
+
+    _wait_zip_applied(api, action_id, key)
+
+    cur = call_api(api, "GET", f"/api/v2/integrations/actions/{action_id}/draft")
+    ver = cur.get("version")
+    log.info("[%s] publishing draft (v%s)…", key, ver)
+    pub = call_api(api, "POST", f"/api/v2/integrations/actions/{action_id}/draft/publish", body={"version": ver})
+    log.info("[%s] PUBLISHED %s (v%s)", key, action_id, pub.get("version"))
+    return f"published {action_id}"
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(prog="deploy_eh_functions.py")
+    p.add_argument("--integration-id", help="ID of your 'Genesys Cloud Function Data Actions' integration.")
+    p.add_argument("--credential-field", default="apiKey", help="Credential field name holding the EH API key (default: apiKey).")
+    p.add_argument("--runtime", default="nodejs22.x")
+    p.add_argument("--timeout", type=int, default=15)
+    p.add_argument("--only", choices=list(FUNCTIONS), action="append")
+    p.add_argument("--confirm", action="store_true", help="Apply (default is dry-run).")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args(argv)
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
+                        format="%(asctime)s %(levelname)s %(name)s %(message)s", datefmt="%H:%M:%S")
+    load_dotenv_files(ENV_FILES)
+    selected = args.only or list(FUNCTIONS)
+
+    for key in selected:
+        js = FUNCTIONS_DIR / FUNCTIONS[key]["js"]
+        if not js.exists():
+            print(f"ERROR: missing {js}", file=sys.stderr)
+            return 2
+
+    if not args.confirm:
+        print("DRY-RUN — no writes.\n")
+        for key in selected:
+            d = FUNCTIONS[key]
+            rt = d["request_template"].replace("%CRED%", args.credential_field)
+            print(f"=== {key} ({d['name']}) ===")
+            print(f"  integration:   {args.integration_id or '(pass --integration-id)'}")
+            print(f"  runtime:       {args.runtime}   handler: index.handler   timeout: {args.timeout}s")
+            print(f"  zip:           {(FUNCTIONS_DIR / d['js'])} -> index.js ({len((FUNCTIONS_DIR / d['js']).read_text())} bytes)")
+            print(f"  requestTemplate: {rt}")
+            print(f"  output:        {json.dumps(d['success_schema']['properties'])}\n")
+        print("Re-run with --integration-id <id> --confirm to deploy (needs the Function integration + apiKey credential set up first).")
+        return 0
+
+    if not args.integration_id:
+        print("ERROR: --integration-id is required with --confirm.", file=sys.stderr)
+        return 2
+    try:
+        api = init_named_api("WRITE")
+    except GenesysConfigError as e:
+        print(f"Error: write client needs GENESYS_WRITE_CLIENT_ID/SECRET — {e}", file=sys.stderr)
+        return 2
+
+    # Use the integration's own name as the action category (matches console behaviour).
+    try:
+        integ = call_api(api, "GET", f"/api/v2/integrations/{args.integration_id}")
+        category = integ.get("name") or "Function Data Actions"
+        log.info("Function integration: %s (%s)", category, args.integration_id)
+    except ApiException as e:
+        print(f"ERROR: couldn't read integration {args.integration_id}: {_err(e)}", file=sys.stderr)
+        return 2
+
+    if sys.stdin.isatty():
+        if input(f"Deploy {len(selected)} function action(s): {', '.join(selected)}? [y/N]: ").strip().lower() != "y":
+            print("Aborted."); return 1
+
+    summary = []
+    for key in selected:
+        try:
+            note = deploy_one(api, key, FUNCTIONS[key], integration_id=args.integration_id,
+                              category=category, credential_field=args.credential_field,
+                              runtime=args.runtime, timeout=args.timeout)
+            summary.append(("✓", key, note))
+        except ApiException as e:
+            log.error("[%s] FAILED status=%s\n  body: %s", key, e.status, _err(e))
+            summary.append(("✗", key, f"status={e.status} (see body above)"))
+        except Exception as e:  # noqa: BLE001
+            log.error("[%s] FAILED: %s", key, e)
+            summary.append(("✗", key, str(e)))
+
+    print("\n" + "─" * 70 + "\nSUMMARY")
+    for s, k, n in summary:
+        print(f" {s}  {k:<12} {n}")
+    print("─" * 70)
+    return 0 if all(s[0] == "✓" for s in summary) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fix_eh_data_actions.py
+++ b/scripts/fix_eh_data_actions.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python3
+"""scripts/fix_eh_data_actions.py — repair the Employment Hero HRIS data actions.
+
+Use case: surface EH leave **balances** in Genesys WFM via the native HRIS
+time-off feature (read-only — no time-off written into Genesys, nothing pushed
+to EH). The EH integration + Basic-Auth credential already work; only the
+data-action OUTPUT contracts + response success templates were wrong (they
+returned EH's raw field names instead of the names the native feature expects,
+with no response mapping). This script rewrites the three READ actions to the
+required contracts via the data-action draft -> publish API:
+
+  get_balance  HRIS - Employment Hero - Get Balance  -> {values:[{timeOffType,name,balance,units,end}]}
+  leave_types  HRIS - Employment Hero - Leave Types   -> {timeOffTypes:[{id,name}]}
+  get_agents   HRIS - Employment Hero - Get Agents     -> {employees:[{id,workEmail}]}
+
+It deliberately does NOT create any Insert/Update (write-to-EH) action — that
+absence is what keeps the integration read-only.
+
+Default is --dry-run (reads the 3 actions, prints the intended changes, writes
+NOTHING). --confirm applies: ensure draft -> PATCH draft -> (optional --test)
+-> publish (unless --no-publish).
+
+OAuth: reuses the SAME write client as provision_users.py (GENESYS_WRITE_CLIENT_*
+in .env.write). That client's ROLE must grant **integrations:action:edit** and
+**integrations:action:view**. The provisioning role (directory/routing/wfm) does
+NOT include these, so add them first (or make a dedicated client) — otherwise you
+get 403s. Verify non-destructively with --self-test before --confirm.
+
+Usage (run with the repo's venv so the SDK + genesys_mcp are importable):
+    PY=~/code/genesys-mcp/.venv/bin/python
+
+    $PY scripts/fix_eh_data_actions.py                       # dry-run (default)
+    $PY scripts/fix_eh_data_actions.py --self-test           # verify edit scope, no live change
+    $PY scripts/fix_eh_data_actions.py --confirm             # apply + publish all three
+    $PY scripts/fix_eh_data_actions.py --confirm --no-publish # apply as drafts, test in console first
+    $PY scripts/fix_eh_data_actions.py --confirm --no-publish --test \
+        --only get_balance --test-employee-id 12345          # live-test one action before publishing
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Make src/ importable when running from the repo root without an editable install.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+import PureCloudPlatformClientV2 as gc
+from PureCloudPlatformClientV2.rest import ApiException
+
+from genesys_mcp.client import (
+    GenesysConfigError,
+    init_api,
+    init_named_api,
+    with_retry_for,
+)
+
+log = logging.getLogger("fix_eh_data_actions")
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Env loading (same pattern/order as provision_users.py)
+# ─────────────────────────────────────────────────────────────────────────────
+
+ENV_FILES = (
+    _REPO_ROOT / ".env.write",                        # write creds (gitignored)
+    _REPO_ROOT / ".env",                              # local read creds (gitignored)
+    Path.home() / ".config" / "genesys-mcp.env",      # documented MCP creds location
+)
+
+
+def load_dotenv_files(paths: tuple[Path, ...]) -> list[Path]:
+    loaded: list[Path] = []
+    for path in paths:
+        if not path.exists():
+            continue
+        for raw in path.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key and key not in os.environ:
+                os.environ[key] = value
+        loaded.append(path)
+    return loaded
+
+
+def call_api(api: gc.ApiClient, method: str, path: str, *, body: Any = None, query: dict | None = None) -> Any:
+    """Thin wrapper around api.call_api() — same as provision_users.py / raw.py."""
+    return api.call_api(
+        resource_path=path,
+        method=method,
+        query_params=query or {},
+        body=body,
+        header_params={"Accept": "application/json", "Content-Type": "application/json"},
+        auth_settings=["PureCloud OAuth"],
+        response_type="object",
+    )
+
+
+def _err_body(exc: ApiException) -> str:
+    body = getattr(exc, "body", None)
+    if isinstance(body, (bytes, bytearray)):
+        body = body.decode("utf-8", errors="replace")
+    return str(body)[:2000] if body else ""
+
+
+def _hint_403(exc: ApiException) -> None:
+    if getattr(exc, "status", None) == 403:
+        log.error(
+            "403 — the write client's role is missing data-action permissions. "
+            "Creating actions needs 'integrations:action:add' (+ 'integrations:action:view'); "
+            "publishing/editing needs 'integrations:action:edit'; --delete-old needs "
+            "'integrations:action:delete'. Add to the GENESYS_WRITE_CLIENT_* role, then retry."
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tenant constants + the standard Genesys error schema (reused on all 3 actions)
+# ─────────────────────────────────────────────────────────────────────────────
+
+EH_HOST = "https://api.yourpayroll.com.au"
+BUSINESS_ID = "363397"
+INTEGRATION_ID = "d648f2d5-1875-4699-bf6a-da0e43279ec1"  # Employment Hero Integration (Basic Auth)
+
+# Standard Genesys data-action error envelope (fetched verbatim from the tenant).
+ERROR_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ErrorBody",
+    "type": "object",
+    "required": ["errorCode", "status", "userMessage"],
+    "properties": {
+        "errors": {"type": "array", "items": {"type": "object"}},
+        "errorCode": {"type": "string"},
+        "status": {"type": "integer"},
+        "correlationId": {"type": ["string", "null"]},
+        "entityId": {"type": ["string", "null"]},
+        "entityName": {"type": ["string", "null"]},
+        "userMessage": {"type": "string"},
+        "userParamsMessage": {"type": ["string", "null"]},
+        "userParams": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"key": {"type": "string"}, "value": {"type": "string"}},
+                "required": ["key", "value"],
+            },
+        },
+        "details": {
+            "type": "array",
+            "items": {
+                "title": "ErrorDetail",
+                "type": "object",
+                "properties": {
+                    "errorCode": {"type": "string"},
+                    "fieldName": {"type": "string"},
+                    "entityId": {"type": ["string", "null"]},
+                    "entityName": {"type": ["string", "null"]},
+                },
+                "required": ["errorCode", "fieldName"],
+            },
+        },
+    },
+    "additionalProperties": False,
+}
+
+_EMPTY_INPUT = {"type": "object", "properties": {}, "additionalProperties": True}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The three corrected action definitions
+#
+# Notes:
+#  • Basic-Auth integrations auto-populate the Authorization header — do NOT set
+#    one here (per the Genesys "Request configuration" docs).
+#  • GET actions use the default request body template "${input.rawRequest}".
+#  • Success templates iterate the raw EH array ($rawResult). If a given endpoint
+#    returns an object wrapper instead of a bare array, change the #foreach source
+#    to $rawResult.<field> and re-test in the Test pane.
+#  • Leave-category names are quoted directly (they don't contain JSON-special
+#    chars); if that ever changes, wrap with a JSON-escaping util.
+# ─────────────────────────────────────────────────────────────────────────────
+
+ACTIONS: dict[str, dict[str, Any]] = {
+    "get_balance": {
+        "id": "custom_-_36282445-3707-4410-962c-c54d910671a6",
+        "name": "HRIS - Employment Hero - Get Balance",
+        "input_schema": {
+            "title": "Request",
+            "type": "object",
+            "properties": {"employeeId": {"type": "string"}, "end": {"type": "string"}},
+            "additionalProperties": True,
+        },
+        "success_schema": {
+            "title": "Response",
+            "type": "object",
+            "required": ["values"],
+            "properties": {
+                "values": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "timeOffType": {"type": "string"},
+                            "name": {"type": "string"},
+                            "balance": {"type": "string"},
+                            "units": {"type": "string"},
+                            "end": {"type": "string"},
+                        },
+                    },
+                }
+            },
+        },
+        "request": {
+            # ?asAtDate honours the date the feature passes; drop it if EH ignores it.
+            "requestUrlTemplate": EH_HOST + "/api/v2/business/" + BUSINESS_ID
+            + "/employee/${input.employeeId}/leavebalances?asAtDate=${input.end}",
+            "requestType": "GET",
+            "headers": {},
+            "requestTemplate": "${input.rawRequest}",
+        },
+        "translation_map": {"items": "$"},
+        "success_template": """{
+  "values": [
+  #foreach($bal in $items)
+    {
+      "timeOffType": "$!{bal.leaveCategoryId}",
+      "name": "$!{bal.leaveCategoryName}",
+      "balance": "$!{bal.accruedAmount}",
+      "units": "$!{bal.unitType}",
+      "end": "$!{input.end}"
+    }#if($foreach.hasNext),#end
+  #end
+  ]
+}""",
+        "test_input": {"employeeId": "REPLACE_ME", "end": "2026-12-31"},
+    },
+    "leave_types": {
+        "id": "custom_-_60e6d8e8-cc7b-4389-9eac-cc3ad3f3de22",
+        "name": "HRIS - Employment Hero - Leave Types",
+        "input_schema": _EMPTY_INPUT,
+        "success_schema": {
+            "title": "Response",
+            "type": "object",
+            "required": ["timeOffTypes"],
+            "properties": {
+                "timeOffTypes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["id", "name"],
+                        # EH returns leave-category id as an INTEGER; keep it integer so it
+                        # matches get_balance's timeOffType (also integer) for the WFM mapping.
+                        "properties": {"id": {"type": "integer"}, "name": {"type": "string"}},
+                    },
+                }
+            },
+        },
+        "request": {
+            "requestUrlTemplate": EH_HOST + "/api/v2/business/" + BUSINESS_ID + "/leavecategory",
+            "requestType": "GET",
+            "headers": {},
+            "requestTemplate": "${input.rawRequest}",
+        },
+        # EH /leavecategory already returns objects with `id` + `name`, so we can
+        # pass the raw array straight through (Genesys disabled #foreach, but a
+        # ${rawResult} passthrough is fine — same trick the blueprint uses).
+        "translation_map": {},
+        "success_template": """{ "timeOffTypes": ${rawResult} }""",
+        "test_input": {},
+    },
+    "get_agents": {
+        "id": "custom_-_1f7ad855-8715-4ad1-8752-44791662e62c",
+        "name": "HRIS - Employment Hero - Get Agents",
+        "input_schema": _EMPTY_INPUT,
+        "success_schema": {
+            "title": "Response",
+            "type": "object",
+            "required": ["employees"],
+            "properties": {
+                "employees": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["id", "workEmail"],
+                        "properties": {"id": {"type": "string"}, "workEmail": {"type": "string"}},
+                    },
+                }
+            },
+        },
+        "request": {
+            # /unstructured returns full records incl. email (plain /employee did not).
+            "requestUrlTemplate": EH_HOST + "/api/v2/business/" + BUSINESS_ID + "/employee/unstructured",
+            "requestType": "GET",
+            "headers": {},
+            "requestTemplate": "${input.rawRequest}",
+        },
+        # ⚠ Confirm the EH email field name in the Test pane — likely 'emailAddress'.
+        "translation_map": {"items": "$"},
+        "success_template": """{
+  "employees": [
+  #foreach($emp in $items)
+    { "id": "$!{emp.id}", "workEmail": "$!{emp.emailAddress}" }#if($foreach.hasNext),#end
+  #end
+  ]
+}""",
+        "test_input": {},
+    },
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data-action draft lifecycle
+# ─────────────────────────────────────────────────────────────────────────────
+
+def get_action(api: gc.ApiClient, action_id: str) -> dict:
+    return call_api(api, "GET", f"/api/v2/integrations/actions/{action_id}")
+
+
+def get_draft(api: gc.ApiClient, action_id: str) -> dict | None:
+    try:
+        return call_api(api, "GET", f"/api/v2/integrations/actions/{action_id}/draft")
+    except ApiException as exc:
+        if exc.status == 404:
+            return None
+        raise
+
+
+def ensure_draft(api: gc.ApiClient, action_id: str) -> dict:
+    """Return the existing draft, or create one from the published action."""
+    existing = get_draft(api, action_id)
+    if existing:
+        log.info("  draft already exists (version %s) — reusing", existing.get("version"))
+        return existing
+    created = call_api(api, "POST", f"/api/v2/integrations/actions/{action_id}/draft", body={})
+    log.info("  created draft (version %s)", created.get("version"))
+    return created
+
+
+def build_patch_body(defn: dict, version: int) -> dict:
+    return {
+        "version": version,
+        "name": defn["name"],
+        "category": "Employment Hero Integration",
+        "contract": {
+            "input": {"inputSchema": defn["input_schema"]},
+            "output": {"successSchema": defn["success_schema"], "errorSchema": ERROR_SCHEMA},
+        },
+        "config": {
+            "request": defn["request"],
+            "response": {
+                "translationMap": {},
+                "translationMapDefaults": {},
+                "successTemplate": defn["success_template"],
+            },
+        },
+        "secure": False,
+    }
+
+
+def patch_draft(api: gc.ApiClient, action_id: str, body: dict) -> dict:
+    return call_api(api, "PATCH", f"/api/v2/integrations/actions/{action_id}/draft", body=body)
+
+
+def test_draft(api: gc.ApiClient, action_id: str, inputs: dict) -> dict:
+    # Best-effort: body shape is {"inputs": {...}}. Prints whatever comes back.
+    return call_api(api, "POST", f"/api/v2/integrations/actions/{action_id}/draft/test",
+                    body={"inputs": inputs})
+
+
+def publish_draft(api: gc.ApiClient, action_id: str, version: int) -> dict:
+    return call_api(api, "POST", f"/api/v2/integrations/actions/{action_id}/draft/publish",
+                    body={"version": version})
+
+
+def create_action(api: gc.ApiClient, defn: dict) -> dict:
+    """Create a NEW custom data action (the contract on a published action is
+    immutable, so we can't fix the old ones in place — we create fresh)."""
+    body = {
+        "name": defn["name"],
+        "category": "Employment Hero Integration",
+        "integrationId": INTEGRATION_ID,
+        "secure": False,
+        "contract": {
+            "input": {"inputSchema": defn["input_schema"]},
+            "output": {"successSchema": defn["success_schema"], "errorSchema": ERROR_SCHEMA},
+        },
+        "config": {
+            "request": defn["request"],
+            "response": {
+                # $rawResult is the raw response *string* — not iterable. We bind
+                # the parsed array to $items via a JSONPath translation map, then
+                # the success template iterates $items.
+                "translationMap": defn.get("translation_map", {"items": "$"}),
+                "translationMapDefaults": {},
+                "successTemplate": defn["success_template"],
+            },
+        },
+    }
+    return call_api(api, "POST", "/api/v2/integrations/actions", body=body)
+
+
+def delete_draft(api: gc.ApiClient, action_id: str) -> None:
+    call_api(api, "DELETE", f"/api/v2/integrations/actions/{action_id}/draft")
+
+
+def find_duplicates_by_name(api: gc.ApiClient, name: str, exclude_id: str) -> list[str]:
+    """IDs of actions on the EH integration with this name, excluding the
+    original broken action — i.e. leftovers from previous script runs."""
+    resp = call_api(api, "GET", "/api/v2/integrations/actions",
+                    query={"pageSize": 200, "includeAuthActions": "false"})
+    return [
+        a["id"] for a in (resp or {}).get("entities", [])
+        if a.get("integrationId") == INTEGRATION_ID
+        and a.get("name") == name and a.get("id") != exclude_id
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Operations
+# ─────────────────────────────────────────────────────────────────────────────
+
+def print_intended(key: str, defn: dict, current: dict | None) -> None:
+    print(f"\n=== {key}  ({defn['name']}) ===")
+    print(f"  action:        will CREATE a NEW action (old broken {defn['id']} stays unless --delete-old)")
+    if current is not None:
+        print(f"  old version:   {current.get('version')}")
+    print(f"  method+url:    {defn['request']['requestType']} {defn['request']['requestUrlTemplate']}")
+    print(f"  output schema: {json.dumps(defn['success_schema']['properties'])}")
+    print("  success template:")
+    for ln in defn["success_template"].splitlines():
+        print(f"      {ln}")
+
+
+def apply_action(write_api: gc.ApiClient, key: str, defn: dict, *,
+                 do_test: bool, test_employee_id: str | None,
+                 delete_old: bool) -> str:
+    # Contracts are immutable once published, so we CREATE a fresh action rather
+    # than patch the old (broken) one.
+    # Idempotency: clear any same-named action from a prior run (best-effort;
+    # leaves the original broken action alone — that's only removed by --delete-old).
+    for dup in find_duplicates_by_name(write_api, defn["name"], defn["id"]):
+        try:
+            call_api(write_api, "DELETE", f"/api/v2/integrations/actions/{dup}")
+            log.info("[%s] cleaned up prior duplicate %s", key, dup)
+        except ApiException as exc:
+            log.warning("[%s] couldn't delete prior duplicate %s (status=%s) — may accumulate",
+                        key, dup, exc.status)
+
+    log.info("[%s] creating NEW action '%s' on the EH integration…", key, defn["name"])
+    created = create_action(write_api, defn)
+    new_id = created.get("id")
+    version = created.get("version", 1)
+    log.info("[%s] CREATED %s (version %s)", key, new_id, version)
+
+    if do_test:
+        inputs = dict(defn["test_input"])
+        if test_employee_id and "employeeId" in inputs:
+            inputs["employeeId"] = test_employee_id
+        log.info("[%s] testing the new action with inputs=%s", key, inputs)
+        try:
+            result = call_api(write_api, "POST",
+                              f"/api/v2/integrations/actions/{new_id}/test",
+                              body=inputs)
+            print(f"[{key}] TEST RESULT:\n{json.dumps(result, indent=2)[:6000]}")
+        except ApiException as exc:
+            log.error("[%s] test call failed (status=%s) — action still created; test in console. body=%s",
+                      key, exc.status, _err_body(exc))
+
+    # Actions created via POST already have a published version and no draft —
+    # they are live immediately, so there is no separate publish step.
+    note = f"created (live) {new_id}"
+
+    if delete_old:
+        old_id = defn["id"]
+        try:
+            call_api(write_api, "DELETE", f"/api/v2/integrations/actions/{old_id}")
+            log.info("[%s] deleted OLD broken action %s", key, old_id)
+            note += f"; deleted old {old_id}"
+        except ApiException as exc:
+            log.warning("[%s] could NOT delete old %s (status=%s) — probably flow-referenced; "
+                        "delete via console after removing the reference. %s",
+                        key, old_id, exc.status, _err_body(exc)[:200])
+            note += f"; OLD {old_id} not deleted ({exc.status})"
+
+    return note
+
+
+def run_self_test(write_api: gc.ApiClient) -> int:
+    """Verify integrations:action:edit non-destructively: create a draft on an
+    action that has none, then delete it. Skips (and reports) if a draft already
+    exists, so we never discard in-progress work."""
+    key = "leave_types"  # chosen because it had no draft; change with care
+    action_id = ACTIONS[key]["id"]
+    log.info("SELF-TEST: checking edit scope via create+delete draft on '%s'", key)
+    try:
+        if get_draft(write_api, action_id) is not None:
+            log.warning("SELF-TEST: a draft already exists on '%s'; not deleting it. "
+                        "view scope OK; assuming edit scope OK. Run --confirm when ready.", key)
+            return 0
+        created = call_api(write_api, "POST", f"/api/v2/integrations/actions/{action_id}/draft", body={})
+        log.info("SELF-TEST: created draft (version %s) — edit scope present", created.get("version"))
+        delete_draft(write_api, action_id)
+        log.info("SELF-TEST: deleted the throwaway draft — clean. Write scope verified.")
+        return 0
+    except ApiException as exc:
+        log.error("SELF-TEST FAILED: status=%s body=%s", exc.status, _err_body(exc))
+        _hint_403(exc)
+        return 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="fix_eh_data_actions.py",
+        description="Repair the Employment Hero HRIS data actions to the native WFM contracts.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Print intended changes; write nothing (default).")
+    mode.add_argument("--confirm", action="store_true", help="Apply changes (ensure draft -> patch -> publish).")
+    mode.add_argument("--self-test", action="store_true", help="Verify edit scope non-destructively; no live change.")
+    parser.add_argument("--no-publish", action="store_true", help="With --confirm: create as drafts but don't publish.")
+    parser.add_argument("--delete-old", action="store_true",
+                        help="With --confirm: delete the old broken action after creating the new one "
+                             "(skips with a warning if it's still referenced by a flow).")
+    parser.add_argument("--test", action="store_true", help="With --confirm: run the data action's Test before publish.")
+    parser.add_argument("--test-employee-id", help="EH employee id for --test on get_balance.")
+    parser.add_argument("--only", choices=list(ACTIONS), action="append",
+                        help="Limit to one or more actions (repeatable). Default: all three.")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s", datefmt="%H:%M:%S",
+    )
+
+    loaded = load_dotenv_files(ENV_FILES)
+    if loaded:
+        log.info("Loaded env from: %s", ", ".join(str(p) for p in loaded))
+
+    selected = args.only or list(ACTIONS)
+
+    # Read client (for dry-run preflight + GETs). Always available.
+    try:
+        read_api = init_api()
+    except GenesysConfigError as exc:
+        print(f"Error: read client needs GENESYS_CLIENT_ID/SECRET — {exc}", file=sys.stderr)
+        return 2
+
+    # ── self-test ──
+    if args.self_test:
+        try:
+            write_api = init_named_api("WRITE")
+        except GenesysConfigError as exc:
+            print(f"Error: write client needs GENESYS_WRITE_CLIENT_ID/SECRET — {exc}", file=sys.stderr)
+            return 2
+        return run_self_test(write_api)
+
+    # ── dry-run (default) ──
+    if not args.confirm:
+        print("DRY-RUN — no writes. Intended changes:")
+        for key in selected:
+            defn = ACTIONS[key]
+            try:
+                current = get_action(read_api, defn["id"])
+            except ApiException as exc:
+                log.error("[%s] could not read action: status=%s", key, exc.status)
+                current = None
+            print_intended(key, defn, current)
+        print("\nThese CREATE NEW actions (published contracts can't be edited). Old broken ones")
+        print("stay unless you pass --delete-old. Re-run with --confirm to apply (needs")
+        print("integrations:action:add + :view; :edit to publish; :delete for --delete-old).")
+        print("Tip: --confirm --no-publish --test --only leave_types  to validate one first.")
+        return 0
+
+    # ── confirm (writes) ──
+    try:
+        write_api = init_named_api("WRITE")
+    except GenesysConfigError as exc:
+        print(f"Error: write client needs GENESYS_WRITE_CLIENT_ID/SECRET — {exc}", file=sys.stderr)
+        return 2
+
+    if args.no_publish:
+        log.info("Note: --no-publish has no effect — API-created actions are live immediately.")
+
+    if sys.stdin.isatty():
+        extra = " and DELETE the old ones" if args.delete_old else ""
+        ans = input(f"About to CREATE (live) {len(selected)} new data action(s){extra}: {', '.join(selected)}. Continue? [y/N]: ")
+        if ans.strip().lower() != "y":
+            print("Aborted.")
+            return 1
+
+    summary: list[tuple[str, str, str]] = []
+    for key in selected:
+        defn = ACTIONS[key]
+        if key in ("get_balance", "get_agents"):
+            log.warning("[%s] needs field renaming, which a normal data action can't do "
+                        "(Genesys disabled #foreach). Deploy it as a FUNCTION data action — see "
+                        "~/genesys-eh-leave-balances/functions/ + the runbook. Skipping here.", key)
+            summary.append(("—", key, "function data action — deploy separately"))
+            continue
+        try:
+            note = apply_action(
+                write_api, key, defn,
+                do_test=args.test, test_employee_id=args.test_employee_id,
+                delete_old=args.delete_old,
+            )
+            summary.append(("✓", key, note))
+        except ApiException as exc:
+            _hint_403(exc)
+            log.error("[%s] FAILED status=%s\n  full body: %s", key, exc.status, _err_body(exc))
+            summary.append(("✗", key, f"status={exc.status} (see full body above)"))
+        except Exception as exc:  # noqa: BLE001
+            summary.append(("✗", key, f"{type(exc).__name__}: {exc}"))
+
+    print("\n" + "─" * 80)
+    print("SUMMARY")
+    for sym, key, note in summary:
+        print(f" {sym}  {key:<14} {note}")
+    print("─" * 80)
+    return 0 if all(s[0] == "✓" for s in summary) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/link_eh_agents.py
+++ b/scripts/link_eh_agents.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""scripts/link_eh_agents.py — set each Genesys agent's HRIS external id from EH.
+
+The native WFM HRIS feature normally matches EH employees to Genesys users by EMAIL,
+but Prvidr's EH emails are mostly personal, so that fails. However EH's `externalId`
+field holds the **Genesys user id** (verified on Lawrence Drayton). So we link directly:
+
+  for each active EH employee:  genesysUserId = externalId,  ehEmployeeId = id
+  -> PUT /api/v2/workforcemanagement/agents/{genesysUserId}/integrations/hris
+       { selectedIntegrationId, associatedIntegrations:[{agentExternalId: ehEmployeeId, integrationId, locked:true}] }
+
+It reads the pairs by executing the `HRIS - Employment Hero - Get Agents` data action
+(which now returns id + workEmail + externalId), resolves each externalId against the
+Genesys directory (skipping ones that aren't real/active users — e.g. ex-staff), and
+only writes for confirmed agents.
+
+Default --dry-run prints the full mapping; --confirm applies. --only-user pilots one
+agent (e.g. Lawrence Drayton e47b91b4-2582-4c78-ae85-ff535ff124ea).
+
+OAuth: write client (GENESYS_WRITE_CLIENT_* in .env.write); needs wfm:agent:edit
+(for the PUT) + integrations:action:execute (to read EH via the data action) + directory:user:view.
+
+    PY=~/code/genesys-mcp/.venv/bin/python
+    $PY scripts/link_eh_agents.py                                   # dry-run, all agents
+    $PY scripts/link_eh_agents.py --only-user e47b91b4-...          # dry-run, just Lawrence
+    $PY scripts/link_eh_agents.py --only-user e47b91b4-... --confirm  # apply for Lawrence (pilot)
+    $PY scripts/link_eh_agents.py --confirm                          # apply for everyone
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+import PureCloudPlatformClientV2 as gc
+from PureCloudPlatformClientV2.rest import ApiException
+
+from genesys_mcp.client import GenesysConfigError, init_api, init_named_api
+
+log = logging.getLogger("link_eh_agents")
+
+ENV_FILES = (
+    _REPO_ROOT / ".env.write",
+    _REPO_ROOT / ".env",
+    Path.home() / ".config" / "genesys-mcp.env",
+)
+WFM_HRIS_INTEGRATION_ID = "1a2ca4e2-24a8-41b4-938a-0330a7c11ad7"  # "WFM Time-off HRIS Integration"
+FUNCTION_INTEGRATION_ID = "0c605b17-82cd-4122-b997-87482a199aac"  # "Function Data Actions (EH)"
+GET_AGENTS_NAME = "HRIS - Employment Hero - Get Agents"
+
+
+def load_dotenv_files(paths) -> None:
+    for path in paths:
+        if not path.exists():
+            continue
+        for raw in path.read_text().splitlines():
+            line = raw.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, _, v = line.partition("=")
+                k = k.strip()
+                if k and k not in os.environ:
+                    os.environ[k] = v.strip().strip('"').strip("'")
+
+
+def call_api(api, method, path, *, body=None, query=None) -> Any:
+    return api.call_api(resource_path=path, method=method, query_params=query or {}, body=body,
+                        header_params={"Accept": "application/json", "Content-Type": "application/json"},
+                        auth_settings=["PureCloud OAuth"], response_type="object")
+
+
+def _err(exc: ApiException) -> str:
+    b = getattr(exc, "body", None)
+    if isinstance(b, (bytes, bytearray)):
+        b = b.decode("utf-8", "replace")
+    return str(b)[:400] if b else ""
+
+
+def find_get_agents_action(api) -> str:
+    resp = call_api(api, "GET", "/api/v2/integrations/actions", query={"pageSize": 200, "includeAuthActions": "false"})
+    # Prefer the FUNCTION-integration version (the new one that returns externalId);
+    # there's also an old same-named action on the EH custom-rest integration.
+    for a in (resp or {}).get("entities", []):
+        if a.get("name") == GET_AGENTS_NAME and a.get("integrationId") == FUNCTION_INTEGRATION_ID:
+            return a["id"]
+    raise SystemExit(f"Could not find '{GET_AGENTS_NAME}' on the Function integration {FUNCTION_INTEGRATION_ID}.")
+
+
+def fetch_employees(api, action_id) -> list[dict]:
+    """Run the Get Agents action and return its employees list. Tries /execute,
+    falls back to /test (parsing the transformed output)."""
+    try:
+        out = call_api(api, "POST", f"/api/v2/integrations/actions/{action_id}/execute", body={})
+        if isinstance(out, dict) and "employees" in out:
+            return out["employees"]
+    except ApiException as exc:
+        log.info("execute not available (%s); falling back to /test", getattr(exc, "status", "?"))
+    # Fallback: /test returns a step trace; pull the "Apply output transformation" result.
+    r = call_api(api, "POST", f"/api/v2/integrations/actions/{action_id}/test", body={})
+    for op in r.get("operations", []):
+        if op.get("name") == "Apply output transformation" and op.get("success"):
+            res = op.get("result")
+            if isinstance(res, str):
+                res = json.loads(res)
+            if isinstance(res, dict):
+                return res.get("employees", [])
+    raise SystemExit(f"Could not get employees from action {action_id}; test success={r.get('success')}")
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(prog="link_eh_agents.py")
+    p.add_argument("--confirm", action="store_true", help="Apply the HRIS associations (default: dry-run).")
+    p.add_argument("--only-user", help="Limit to a single Genesys user id (pilot).")
+    p.add_argument("--integration-id", default=WFM_HRIS_INTEGRATION_ID, help="WFM HRIS integration id.")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args(argv)
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
+                        format="%(asctime)s %(levelname)s %(name)s %(message)s", datefmt="%H:%M:%S")
+    load_dotenv_files(ENV_FILES)
+
+    read_api = init_api()
+    # The write client is needed to EXECUTE the data action (integrations:action:execute)
+    # to read EH — and for the PUTs. Read client handles directory lookups.
+    try:
+        write_api = init_named_api("WRITE")
+    except GenesysConfigError as exc:
+        print(f"Error: write client needs GENESYS_WRITE_CLIENT_* — {exc}", file=sys.stderr)
+        return 2
+    action_id = find_get_agents_action(read_api)
+    log.info("Get Agents action: %s", action_id)
+    employees = fetch_employees(write_api, action_id)
+    log.info("EH (non-terminated) employees returned: %d", len(employees))
+
+    # Build candidate links: genesysUserId(=externalId) -> ehId, resolving against the directory.
+    rows = []  # (genesysUserId, ehId, genesysName, genesysEmail, status)
+    for e in employees:
+        gid, ehid = (e.get("externalId") or "").strip(), str(e.get("id") or "").strip()
+        if not gid or not ehid:
+            continue
+        if args.only_user and gid != args.only_user:
+            continue
+        try:
+            u = call_api(read_api, "GET", f"/api/v2/users/{gid}")
+            rows.append((gid, ehid, u.get("name", "?"), u.get("email", "?"), u.get("state", "?")))
+        except ApiException as exc:
+            if getattr(exc, "status", None) == 404:
+                rows.append((gid, ehid, "(not a Genesys user)", "", "missing"))
+            else:
+                rows.append((gid, ehid, f"(lookup error {exc.status})", "", "error"))
+
+    linkable = [r for r in rows if r[4] == "active"]
+    print(f"\n{'EH id':<10} {'Genesys user':<28} {'email':<32} {'state':<8} {'Genesys id'}")
+    print("-" * 110)
+    for gid, ehid, name, email, state in rows:
+        flag = "" if state == "active" else "   <-- skip"
+        print(f"{ehid:<10} {name[:27]:<28} {email[:31]:<32} {state:<8} {gid}{flag}")
+    print("-" * 110)
+    print(f"{len(linkable)} linkable active agents, {len(rows) - len(linkable)} skipped (not active Genesys users).")
+
+    if not args.confirm:
+        print("\nDRY-RUN — nothing written. Re-run with --confirm to set HRIS associations.")
+        print("Tip: --only-user e47b91b4-2582-4c78-ae85-ff535ff124ea --confirm  to pilot on Lawrence first.")
+        return 0
+
+    ok = err = 0
+    for gid, ehid, name, email, state in linkable:
+        try:
+            # 1) Set the Genesys user's Employee ID (employerInfo.employeeId) — this is what the
+            #    balance workflow's "Get Employment Hero ID" reads to resolve the EH employee.
+            u = call_api(write_api, "GET", f"/api/v2/users/{gid}", query={"expand": "employerInfo"})
+            ei = dict(u.get("employerInfo") or {})
+            ei["employeeId"] = ehid
+            call_api(write_api, "PATCH", f"/api/v2/users/{gid}",
+                     body={"version": u["version"], "employerInfo": ei})
+            # 2) Also set the WFM HRIS agent association (the agent's HRIS affiliation).
+            assoc = {"selectedIntegrationId": args.integration_id,
+                     "associatedIntegrations": [
+                         {"agentExternalId": ehid, "integrationId": args.integration_id, "locked": True}]}
+            call_api(write_api, "PUT", f"/api/v2/workforcemanagement/agents/{gid}/integrations/hris", body=assoc)
+            log.info("linked %s (%s) -> EH %s (employeeId + WFM affiliation)", name, gid, ehid)
+            ok += 1
+        except ApiException as exc:
+            log.error("FAILED %s (%s): status=%s %s", name, gid, exc.status, _err(exc))
+            err += 1
+    print(f"\nDone: {ok} linked, {err} failed.")
+    return 0 if err == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/genesys_mcp/_availability.py
+++ b/src/genesys_mcp/_availability.py
@@ -1,0 +1,94 @@
+"""Data-availability watermark for the users/details analytics jobs API.
+
+Genesys settles presence/routing detail data asynchronously. The
+``/api/v2/analytics/users/details/jobs/availability`` endpoint returns a
+``dataAvailabilityDate`` watermark: detail queries for any window extending
+past it come back **partial, with no error and no flag** — the job succeeds
+and simply omits the not-yet-settled tail.
+
+This bit us in production: a coaching brief collected at 06:00 for the prior
+day read the last recorded presence session as the agent's "logout", but the
+watermark was hours behind, so an agent who worked into the evening looked
+like she left mid-afternoon. Every presence-derived figure (login/logout,
+online/on-queue totals, the day timeline) was silently truncated while her
+conversation stats — a separate, near-real-time pipeline — were complete.
+
+:func:`presence_data_availability` fetches the watermark once and reports
+whether a requested interval is fully settled, so tools can surface
+``complete: false`` + ``data_available_until`` instead of lying by omission.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import PureCloudPlatformClientV2 as gc
+
+from genesys_mcp._intervals import parse_iso as _parse_iso
+from genesys_mcp.client import to_dict, with_retry
+
+logger = logging.getLogger(__name__)
+
+
+def presence_data_availability(api: gc.AnalyticsApi, interval_end: Any) -> dict[str, Any]:
+    """Assess whether ``interval_end`` is fully settled in users/details data.
+
+    ``interval_end`` is a timezone-aware ``datetime`` (the end of the requested
+    window). Returns a dict always safe to merge into a tool response:
+
+      - ``complete``            — bool | None. True when the watermark is at or
+                                  past ``interval_end``; False when it is
+                                  behind (data is partial); None when the
+                                  watermark could not be read (fail-open: we
+                                  don't block the answer, but we don't claim
+                                  completeness either).
+      - ``data_available_until``— ISO-Z watermark string, or None if unknown.
+      - ``lag_seconds``         — how far the window end is beyond the watermark
+                                  (0 when complete; None when unknown).
+      - ``note``                — human/LLM-readable explanation when not complete.
+
+    Never raises: a watermark lookup failure degrades to ``complete: None`` so
+    the underlying data query still returns.
+    """
+    watermark = None
+    try:
+        resp = with_retry(api.get_analytics_users_details_jobs_availability)()
+        data = to_dict(resp) or {}
+        raw = data.get("dataAvailabilityDate") or data.get("data_availability_date")
+        if raw:
+            watermark = _parse_iso(raw)
+    except Exception as exc:  # noqa: BLE001 — fail open, never block the data query
+        logger.warning("users/details availability watermark lookup failed: %s", exc)
+
+    if watermark is None:
+        return {
+            "complete": None,
+            "data_available_until": None,
+            "lag_seconds": None,
+            "note": (
+                "Could not read the Genesys data-availability watermark; "
+                "presence data may be incomplete for very recent windows."
+            ),
+        }
+
+    watermark_z = watermark.isoformat().replace("+00:00", "Z")
+    if watermark >= interval_end:
+        return {
+            "complete": True,
+            "data_available_until": watermark_z,
+            "lag_seconds": 0,
+            "note": None,
+        }
+
+    lag = (interval_end - watermark).total_seconds()
+    return {
+        "complete": False,
+        "data_available_until": watermark_z,
+        "lag_seconds": int(lag),
+        "note": (
+            f"Presence data is only settled up to {watermark_z}, which is before "
+            f"the end of the requested window. Sessions after that time are not "
+            f"yet available and are omitted — totals, last-recorded presence, and "
+            f"any derived logout time are incomplete for this interval."
+        ),
+    }

--- a/src/genesys_mcp/tools/presence.py
+++ b/src/genesys_mcp/tools/presence.py
@@ -14,6 +14,7 @@ import PureCloudPlatformClientV2 as gc
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
+from genesys_mcp._availability import presence_data_availability
 from genesys_mcp._intervals import INTERVAL_HELP_STRING
 from genesys_mcp._intervals import default_interval as _default_interval
 from genesys_mcp._intervals import parse_iso as _parse_iso
@@ -72,6 +73,12 @@ def register(mcp: FastMCP) -> None:
           measure duration reliably).
         - Use the AnalyticsApi job results cursor under the hood; if the cap is hit,
           'truncated': true is set in the response.
+        - Data availability: presence detail settles asynchronously. The response
+          carries 'data_complete' (False when the interval extends past Genesys'
+          settled watermark 'data_available_until'), plus a 'data_availability_note'.
+          When data_complete is False, sessions after the watermark are MISSING —
+          do not treat the last returned session as the agent's logout, and treat
+          per-presence totals as lower bounds.
         """
         if not user_ids:
             raise ValueError("user_ids must contain at least one id.")
@@ -88,6 +95,11 @@ def register(mcp: FastMCP) -> None:
             raise ValueError(f"Invalid interval {interval!r}: {exc}") from exc
 
         api = gc.AnalyticsApi(get_api())
+        # Presence detail data settles asynchronously; a window extending past
+        # the availability watermark returns partial with no error. Check it up
+        # front so the response can flag incompleteness rather than imply the
+        # last recorded session was the agent's real logout.
+        availability = presence_data_availability(api, interval_end)
         body = {
             "interval": interval,
             "order": "asc",
@@ -208,5 +220,13 @@ def register(mcp: FastMCP) -> None:
             "interval": interval,
             "presence_filter": list(keep) if keep else None,
             "truncated": truncated,
+            # v1.17: data-availability watermark. `data_complete` is False when
+            # the interval extends past what Genesys has settled — sessions after
+            # `data_available_until` are omitted, so totals and any inferred
+            # logout time are partial. Consumers must not treat the last session
+            # as the agent's real end-of-day when this is False.
+            "data_complete": availability["complete"],
+            "data_available_until": availability["data_available_until"],
+            "data_availability_note": availability["note"],
             "users": out_users,
         }

--- a/src/genesys_mcp/tools/reports.py
+++ b/src/genesys_mcp/tools/reports.py
@@ -22,6 +22,7 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
 from genesys_mcp._aggregates import accumulate_metric_stats
+from genesys_mcp._availability import presence_data_availability
 from genesys_mcp._intervals import INTERVAL_HELP_STRING
 from genesys_mcp._intervals import default_interval as _default_interval
 from genesys_mcp._intervals import now_utc as _now_utc
@@ -966,6 +967,12 @@ def register(mcp: FastMCP) -> None:
 
         Returns per-user counts, totals, and per-instance lists so a TL can drill in.
         Sorted by overrun frequency.
+
+        Data availability: presence detail settles asynchronously. The response
+        carries 'data_complete' (False when the interval extends past Genesys'
+        settled watermark 'data_available_until') plus 'data_availability_note'.
+        When False, evening break/meal/away sessions after the watermark are
+        missing, so overrun counts and away totals understate the day.
         """
         # Reuse the presence_sessions tool's data fetching logic by calling the
         # same job pipeline directly here — keeps this tool self-contained.
@@ -980,6 +987,10 @@ def register(mcp: FastMCP) -> None:
             raise ValueError(f"Invalid interval {interval!r}") from exc
 
         api = gc.AnalyticsApi(get_api())
+        # Presence detail settles asynchronously; a window past the availability
+        # watermark returns partial with no error (an evening break/meal can be
+        # missing entirely). Surface it so overrun counts aren't read as complete.
+        availability = presence_data_availability(api, interval_end)
         body = {
             "interval": interval,
             "order": "asc",
@@ -1141,6 +1152,13 @@ def register(mcp: FastMCP) -> None:
         return {
             "interval": interval,
             "as_of_utc": _now_utc().isoformat().replace("+00:00", "Z"),
+            # v1.17: data-availability watermark. When `data_complete` is False,
+            # presence detail is only settled to `data_available_until`; evening
+            # break/meal sessions after that point are missing, so overrun counts
+            # and away totals understate the day.
+            "data_complete": availability["complete"],
+            "data_available_until": availability["data_available_until"],
+            "data_availability_note": availability["note"],
             "break_target_min": break_target_min,
             "meal_target_min": meal_target_min,
             "pre_break_target_min": pre_break_target_min,

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -1,0 +1,76 @@
+"""Data-availability watermark helper + its wiring into the presence tools.
+
+Regression guard for the production incident where a coaching brief read an
+agent's last recorded presence session as her "logout" while the Genesys
+users/details watermark was hours behind, silently truncating her evening.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from genesys_mcp import _availability
+from genesys_mcp._availability import presence_data_availability
+
+
+@pytest.fixture(autouse=True)
+def _passthrough_to_dict(monkeypatch):
+    # The real to_dict routes through get_api().sanitize_for_serialization,
+    # which needs an initialised SDK client. The fake API already returns
+    # plain dicts, so pass them through.
+    monkeypatch.setattr(_availability, "to_dict", lambda obj: obj)
+
+
+class _FakeAvailabilityApi:
+    """Minimal stand-in exposing only the availability endpoint."""
+
+    def __init__(self, watermark: str | None = None, raise_exc: bool = False):
+        self._watermark = watermark
+        self._raise = raise_exc
+
+    def get_analytics_users_details_jobs_availability(self):
+        if self._raise:
+            raise RuntimeError("boom")
+        return {"dataAvailabilityDate": self._watermark} if self._watermark else {}
+
+
+def _end(iso: str) -> datetime:
+    return datetime.fromisoformat(iso).replace(tzinfo=timezone.utc)
+
+
+class TestPresenceDataAvailability:
+    def test_complete_when_watermark_at_or_past_end(self):
+        api = _FakeAvailabilityApi("2026-07-13T14:00:00Z")
+        out = presence_data_availability(api, _end("2026-07-13T14:00:00"))
+        assert out["complete"] is True
+        assert out["lag_seconds"] == 0
+        assert out["note"] is None
+        assert out["data_available_until"] == "2026-07-13T14:00:00Z"
+
+    def test_incomplete_when_watermark_behind_end(self):
+        # The Deanna incident: watermark 07:12Z, window ends 14:00Z next-day close.
+        api = _FakeAvailabilityApi("2026-07-13T07:12:12Z")
+        out = presence_data_availability(api, _end("2026-07-13T14:00:00"))
+        assert out["complete"] is False
+        assert out["data_available_until"] == "2026-07-13T07:12:12Z"
+        assert out["lag_seconds"] == pytest.approx(24468, abs=2)
+        assert "not yet available" in out["note"]
+
+    def test_unknown_when_endpoint_errors(self):
+        api = _FakeAvailabilityApi(raise_exc=True)
+        out = presence_data_availability(api, _end("2026-07-13T14:00:00"))
+        assert out["complete"] is None
+        assert out["data_available_until"] is None
+        assert out["lag_seconds"] is None
+        assert "Could not read" in out["note"]
+
+    def test_unknown_when_field_missing(self):
+        api = _FakeAvailabilityApi(watermark=None)
+        out = presence_data_availability(api, _end("2026-07-13T14:00:00"))
+        assert out["complete"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -216,7 +216,7 @@ wheels = [
 
 [[package]]
 name = "genesys-mcp"
-version = "1.15.0"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Problem
users/details (presence/routing) data settles asynchronously behind a `dataAvailabilityDate` watermark. A detail query for a window past it returns **partial data with no error and no flag**. A coaching brief collected at 06:00 for the prior day read an agent's last recorded presence session as her logout (5:37pm) while she had worked into the evening — the watermark was ~10h behind the day close, so her evening on-queue time didn't exist in the response. Conversation stats (separate near-real-time pipeline) were complete, so only presence-derived figures were wrong.

## Fix
- `presence_sessions` and `break_overrun_report` check the watermark (`GET /api/v2/analytics/users/details/jobs/availability`) and return `data_complete` / `data_available_until` / `data_availability_note`.
- `data_complete: false` ⇒ last session is NOT the logout, totals are lower bounds. Fail-open: watermark lookup failure ⇒ `data_complete: null`, never blocks the query.
- New shared `_availability.py` helper.

## Tests
634 passed (4 new in tests/test_availability.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)