### PR TITLE
Fix conversation detail availability reporting

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,13 +13,15 @@
 
   When `data_complete` is `false`, consumers must not treat the last returned session as the agent's logout, and must treat per-presence totals / overrun counts as lower bounds. The watermark lookup never blocks the data query — a failure degrades to `data_complete: null`.
 
+- **`repeat_caller_report`** and **`repeat_caller_deep_dive`** now apply the same contract to the conversation-jobs datalake via `GET /api/v2/analytics/conversations/details/jobs/availability`. Their repeat-caller counts, funnels and recommendations are explicitly provisional whenever the requested interval extends past that watermark. Summary mode preserves the availability fields.
+
 ### Internal
 
-- New `genesys_mcp/_availability.py` (`presence_data_availability`) — shared, fail-open watermark helper used by both tools.
+- `genesys_mcp/_availability.py` now provides shared fail-open helpers for both users/details and conversations/details job families.
 
 ### Tests
 
-- New `tests/test_availability.py` (4 tests): complete / incomplete (the Deanna incident: 07:12Z watermark vs a 14:00Z day-close) / endpoint-error / missing-field. Suite 634 passed.
+- `tests/test_availability.py` covers complete / incomplete (the Deanna incident: 07:12Z watermark vs a 14:00Z day-close) / endpoint-error / missing-field plus the conversation-jobs watermark family.
 
 ## v1.16.0 — 14 July 2026
 

--- a/src/genesys_mcp/_availability.py
+++ b/src/genesys_mcp/_availability.py
@@ -30,6 +30,75 @@ from genesys_mcp.client import to_dict, with_retry
 logger = logging.getLogger(__name__)
 
 
+def _details_data_availability(
+    api: gc.AnalyticsApi,
+    interval_end: Any,
+    *,
+    kind: str,
+) -> dict[str, Any]:
+    """Assess whether ``interval_end`` is fully settled in a details datalake."""
+    if kind == "users":
+        endpoint = api.get_analytics_users_details_jobs_availability
+        label = "Presence data"
+    elif kind == "conversations":
+        endpoint = api.get_analytics_conversations_details_jobs_availability
+        label = "Conversation detail data"
+    else:  # defensive: callers are internal and must choose a real API family
+        raise ValueError(f"Unsupported details availability kind: {kind!r}")
+
+    watermark = None
+    try:
+        resp = with_retry(endpoint)()
+        data = to_dict(resp) or {}
+        raw = data.get("dataAvailabilityDate") or data.get("data_availability_date")
+        if raw:
+            watermark = _parse_iso(raw)
+    except Exception as exc:  # noqa: BLE001 — fail open, never block the data query
+        logger.warning("%s/details availability watermark lookup failed: %s", kind, exc)
+
+    if watermark is None:
+        return {
+            "complete": None,
+            "data_available_until": None,
+            "lag_seconds": None,
+            "note": (
+                "Could not read the Genesys data-availability watermark; "
+                f"{label.lower()} may be incomplete for very recent windows."
+            ),
+        }
+
+    watermark_z = watermark.isoformat().replace("+00:00", "Z")
+    if watermark >= interval_end:
+        return {
+            "complete": True,
+            "data_available_until": watermark_z,
+            "lag_seconds": 0,
+            "note": None,
+        }
+
+    lag = (interval_end - watermark).total_seconds()
+    if kind == "users":
+        incomplete_note = (
+            f"Presence data is only settled up to {watermark_z}, which is before "
+            f"the end of the requested window. Sessions after that time are not "
+            f"yet available and are omitted — totals, last-recorded presence, and "
+            f"any derived logout time are incomplete for this interval."
+        )
+    else:
+        incomplete_note = (
+            f"{label} is only settled up to {watermark_z}, which is before "
+            f"the end of the requested window. Records after that time are not "
+            f"yet available and are omitted, so this interval is incomplete."
+        )
+
+    return {
+        "complete": False,
+        "data_available_until": watermark_z,
+        "lag_seconds": int(lag),
+        "note": incomplete_note,
+    }
+
+
 def presence_data_availability(api: gc.AnalyticsApi, interval_end: Any) -> dict[str, Any]:
     """Assess whether ``interval_end`` is fully settled in users/details data.
 
@@ -50,45 +119,14 @@ def presence_data_availability(api: gc.AnalyticsApi, interval_end: Any) -> dict[
     Never raises: a watermark lookup failure degrades to ``complete: None`` so
     the underlying data query still returns.
     """
-    watermark = None
-    try:
-        resp = with_retry(api.get_analytics_users_details_jobs_availability)()
-        data = to_dict(resp) or {}
-        raw = data.get("dataAvailabilityDate") or data.get("data_availability_date")
-        if raw:
-            watermark = _parse_iso(raw)
-    except Exception as exc:  # noqa: BLE001 — fail open, never block the data query
-        logger.warning("users/details availability watermark lookup failed: %s", exc)
+    return _details_data_availability(api, interval_end, kind="users")
 
-    if watermark is None:
-        return {
-            "complete": None,
-            "data_available_until": None,
-            "lag_seconds": None,
-            "note": (
-                "Could not read the Genesys data-availability watermark; "
-                "presence data may be incomplete for very recent windows."
-            ),
-        }
 
-    watermark_z = watermark.isoformat().replace("+00:00", "Z")
-    if watermark >= interval_end:
-        return {
-            "complete": True,
-            "data_available_until": watermark_z,
-            "lag_seconds": 0,
-            "note": None,
-        }
+def conversation_data_availability(api: gc.AnalyticsApi, interval_end: Any) -> dict[str, Any]:
+    """Assess whether ``interval_end`` is fully settled in conversation jobs data.
 
-    lag = (interval_end - watermark).total_seconds()
-    return {
-        "complete": False,
-        "data_available_until": watermark_z,
-        "lag_seconds": int(lag),
-        "note": (
-            f"Presence data is only settled up to {watermark_z}, which is before "
-            f"the end of the requested window. Sessions after that time are not "
-            f"yet available and are omitted — totals, last-recorded presence, and "
-            f"any derived logout time are incomplete for this interval."
-        ),
-    }
+    Conversation aggregate and synchronous detail-query APIs are separate. This
+    watermark applies specifically to tools backed by
+    ``/analytics/conversations/details/jobs``.
+    """
+    return _details_data_availability(api, interval_end, kind="conversations")

--- a/src/genesys_mcp/tools/reports.py
+++ b/src/genesys_mcp/tools/reports.py
@@ -22,7 +22,7 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
 from genesys_mcp._aggregates import accumulate_metric_stats
-from genesys_mcp._availability import presence_data_availability
+from genesys_mcp._availability import conversation_data_availability, presence_data_availability
 from genesys_mcp._intervals import INTERVAL_HELP_STRING
 from genesys_mcp._intervals import default_interval as _default_interval
 from genesys_mcp._intervals import now_utc as _now_utc
@@ -244,6 +244,10 @@ def _slim_deep_dive_response(resp: dict) -> dict:
 
     return {
         "interval": resp.get("interval"),
+        "as_of_utc": resp.get("as_of_utc"),
+        "data_complete": resp.get("data_complete"),
+        "data_available_until": resp.get("data_available_until"),
+        "data_availability_note": resp.get("data_availability_note"),
         "media_type": resp.get("media_type"),
         "scope": slim_scope,
         "org_rollup": resp.get("org_rollup") or {},
@@ -279,6 +283,16 @@ def _seg_dur_s(seg: dict) -> float:
         return (_parse_iso(en_raw) - _parse_iso(st_raw)).total_seconds()
     except Exception:
         return 0.0
+
+
+def _conversation_job_availability(filters_body: dict[str, Any]) -> dict[str, Any]:
+    """Return the fail-open availability contract for a conversation-job body."""
+    api = gc.AnalyticsApi(get_api())
+    try:
+        interval_end = _parse_iso(str(filters_body["interval"]).split("/", 1)[1])
+    except Exception as exc:
+        raise ValueError(f"Invalid interval {filters_body.get('interval')!r}") from exc
+    return conversation_data_availability(api, interval_end)
 
 
 def _run_conv_details_job(filters_body: dict[str, Any], max_pages: int = 20) -> list[dict]:
@@ -352,6 +366,12 @@ def register(mcp: FastMCP) -> None:
 
         Sorted by acd_offered_count desc, then total. Backed by
         /api/v2/analytics/conversations/details/jobs (async, paginated).
+
+        Data availability: the response carries ``data_complete`` (False when
+        the requested interval extends past the conversation-jobs datalake
+        watermark), ``data_available_until`` and ``data_availability_note``.
+        When incomplete, recent conversations can be absent and every funnel or
+        repeat-caller count is a lower bound.
         """
         interval = interval or _default_interval(7)
         excluded = set(exclude_anis or [])
@@ -396,6 +416,7 @@ def register(mcp: FastMCP) -> None:
             "segmentFilters": [segment_filter],
         }
 
+        availability = _conversation_job_availability(body)
         convs = _run_conv_details_job(body)
 
         # Org-wide funnel counters (across every inbound conv we pulled, not just repeaters)
@@ -480,6 +501,9 @@ def register(mcp: FastMCP) -> None:
 
         return {
             "interval": interval,
+            "data_complete": availability["complete"],
+            "data_available_until": availability["data_available_until"],
+            "data_availability_note": availability["note"],
             "media_type": media_type,
             "total_conversations": org_total,
             "unique_callers": len(by_ani),
@@ -563,6 +587,11 @@ def register(mcp: FastMCP) -> None:
         Honest about data gaps: in tenants with sparse STA coverage (short calls, non-recorded
         queues), most rows will show topics from queue_fallback only and sentiment_trend
         'insufficient_data'. The funnel data is still valid.
+
+        The top-level ``data_complete`` / ``data_available_until`` fields refer
+        to the async conversation-details jobs datalake. When False, recent
+        conversations are missing, so repeat-caller counts and recommendations
+        are provisional even if the enrichment calls themselves succeeded.
         """
         interval = interval or _default_interval(7)
         excluded = set(exclude_anis or [])
@@ -605,6 +634,7 @@ def register(mcp: FastMCP) -> None:
             ],
             "segmentFilters": [segment_filter],
         }
+        availability = _conversation_job_availability(body)
         convs = _run_conv_details_job(body)
 
         # ---- 2. Group by ANI with the canonical IVR/ACD/answered classification ----
@@ -860,6 +890,9 @@ def register(mcp: FastMCP) -> None:
         full_response = {
             "interval": interval,
             "as_of_utc": _now_utc().isoformat().replace("+00:00", "Z"),
+            "data_complete": availability["complete"],
+            "data_available_until": availability["data_available_until"],
+            "data_availability_note": availability["note"],
             "media_type": media_type,
             "scope": {
                 "max_anis": max_anis,

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -16,7 +16,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "src"))
 
 from genesys_mcp import _availability
-from genesys_mcp._availability import presence_data_availability
+from genesys_mcp._availability import conversation_data_availability, presence_data_availability
 
 
 @pytest.fixture(autouse=True)
@@ -35,6 +35,11 @@ class _FakeAvailabilityApi:
         self._raise = raise_exc
 
     def get_analytics_users_details_jobs_availability(self):
+        if self._raise:
+            raise RuntimeError("boom")
+        return {"dataAvailabilityDate": self._watermark} if self._watermark else {}
+
+    def get_analytics_conversations_details_jobs_availability(self):
         if self._raise:
             raise RuntimeError("boom")
         return {"dataAvailabilityDate": self._watermark} if self._watermark else {}
@@ -74,3 +79,10 @@ class TestPresenceDataAvailability:
         api = _FakeAvailabilityApi(watermark=None)
         out = presence_data_availability(api, _end("2026-07-13T14:00:00"))
         assert out["complete"] is None
+
+    def test_conversation_jobs_use_their_own_watermark(self):
+        api = _FakeAvailabilityApi("2026-07-13T07:12:12Z")
+        out = conversation_data_availability(api, _end("2026-07-13T14:00:00"))
+        assert out["complete"] is False
+        assert out["data_available_until"] == "2026-07-13T07:12:12Z"
+        assert "Conversation detail data" in out["note"]


### PR DESCRIPTION
## Summary
- query the Genesys conversation-details jobs availability watermark
- expose completeness metadata on repeat-caller report and deep-dive responses
- preserve availability metadata in summary mode without changing the shared job helper contract

## Why
Async conversation-detail jobs can lag behind aggregate analytics. downstream consumers needs an explicit watermark so it does not treat provisional repeat-caller results as settled closed-day data.

## Validation
- uv run pytest -q (635 passed)
- git diff --check

## Rollout
Merge this before laggyzee/Genesys-mcp-frontend so downstream consumers receives the new data_complete contract.
