### PR TITLE
Add reconciled presence fallback

### DIFF
--- a/src/genesys_mcp/_user_details.py
+++ b/src/genesys_mcp/_user_details.py
@@ -1,0 +1,323 @@
+"""Shared user-detail collection with a reconciled recent-data fallback.
+
+The async ``analytics/users/details/jobs`` archive is authoritative but can lag the
+previous local day by many hours.  For an interval beyond that watermark we query the
+recent synchronous endpoint, then reconcile its per-user presence durations against
+``analytics/users/aggregates/query`` before allowing consumers to treat it as complete.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import threading
+import time
+from collections import defaultdict
+from typing import Any
+
+import PureCloudPlatformClientV2 as gc
+
+from genesys_mcp._availability import presence_data_availability
+from genesys_mcp._intervals import parse_iso
+from genesys_mcp.client import get_api, to_dict, with_retry
+
+logger = logging.getLogger(__name__)
+
+_SYNC_PAGE_SIZE = 100
+_CACHE_TTL_SECONDS = 300
+_RECONCILIATION_MIN_TOLERANCE_SECONDS = 120
+_RECONCILIATION_FRACTION = 0.02
+_cache_lock = threading.Lock()
+_cache: dict[tuple[str, tuple[str, ...], int], tuple[float, dict[str, Any]]] = {}
+
+
+def clear_user_details_cache() -> None:
+    """Clear the short-lived cache (primarily for tests and explicit refreshes)."""
+    with _cache_lock:
+        _cache.clear()
+
+
+def _user_filter(user_ids: list[str]) -> dict[str, Any]:
+    return {
+        "type": "or",
+        "predicates": [
+            {
+                "type": "dimension",
+                "dimension": "userId",
+                "operator": "matches",
+                "value": user_id,
+            }
+            for user_id in user_ids
+        ],
+    }
+
+
+def _aggregate_user_filter(user_ids: list[str]) -> dict[str, Any]:
+    """Return the predicate shape accepted by users/aggregates/query."""
+    return {
+        "type": "or",
+        "predicates": [
+            {"dimension": "userId", "value": user_id}
+            for user_id in user_ids
+        ],
+    }
+
+
+def _async_details(api: Any, user_ids: list[str], interval: str, max_pages: int) -> tuple[list[dict], bool]:
+    body = {"interval": interval, "order": "asc", "userFilters": [_user_filter(user_ids)]}
+    submit = with_retry(api.post_analytics_users_details_jobs)(body=body)
+    job_id = getattr(submit, "job_id", None) or (to_dict(submit) or {}).get("jobId")
+    if not job_id:
+        raise RuntimeError(f"users/details/jobs submit returned no jobId: {to_dict(submit)}")
+
+    for _ in range(30):
+        status_response = with_retry(api.get_analytics_users_details_job)(job_id=job_id)
+        state = getattr(status_response, "state", None) or (to_dict(status_response) or {}).get("state")
+        if state == "FULFILLED":
+            break
+        if state in ("FAILED", "CANCELLED", "EXPIRED"):
+            raise RuntimeError(f"job {job_id} terminated in state {state}")
+        time.sleep(1)
+    else:
+        raise RuntimeError(f"job {job_id} did not reach FULFILLED within 30s")
+
+    details: list[dict] = []
+    cursor: str | None = None
+    truncated = False
+    for _ in range(max_pages):
+        kwargs: dict[str, Any] = {"job_id": job_id, "page_size": 1000}
+        if cursor:
+            kwargs["cursor"] = cursor
+        page = to_dict(with_retry(api.get_analytics_users_details_job_results)(**kwargs)) or {}
+        details.extend(page.get("userDetails") or [])
+        cursor = page.get("cursor")
+        if not cursor:
+            break
+    else:
+        truncated = cursor is not None
+    return details, truncated
+
+
+def _merge_user_detail_page(merged: dict[str, dict], rows: list[dict]) -> None:
+    for row in rows:
+        user_id = row.get("userId")
+        if not user_id:
+            continue
+        target = merged.setdefault(user_id, {"userId": user_id, "primaryPresence": [], "routingStatus": []})
+        target["primaryPresence"].extend(row.get("primaryPresence") or [])
+        target["routingStatus"].extend(row.get("routingStatus") or [])
+
+
+def _sync_details(api: Any, user_ids: list[str], interval: str, max_pages: int) -> tuple[list[dict], bool, int]:
+    merged: dict[str, dict] = {}
+    total_hits = 0
+    truncated = False
+    for page_number in range(1, max_pages + 1):
+        body = {
+            "interval": interval,
+            "order": "asc",
+            "userFilters": [_user_filter(user_ids)],
+            "paging": {"pageSize": _SYNC_PAGE_SIZE, "pageNumber": page_number},
+        }
+        response = to_dict(with_retry(api.post_analytics_users_details_query)(body=body)) or {}
+        rows = response.get("userDetails") or []
+        total_hits = int(response.get("totalHits") or 0)
+        _merge_user_detail_page(merged, rows)
+        if page_number * _SYNC_PAGE_SIZE >= total_hits:
+            break
+        if not rows:
+            truncated = True
+            break
+    else:
+        truncated = max_pages * _SYNC_PAGE_SIZE < total_hits
+
+    for row in merged.values():
+        row["primaryPresence"].sort(key=lambda item: item.get("startTime") or "")
+        row["routingStatus"].sort(key=lambda item: item.get("startTime") or "")
+    return list(merged.values()), truncated, total_hits
+
+
+def _qualified_aggregates(api: Any, user_ids: list[str], interval: str) -> dict[str, dict[str, dict[str, float]]]:
+    body = {
+        "interval": interval,
+        "groupBy": ["userId"],
+        "filter": {"type": "and", "clauses": [_aggregate_user_filter(user_ids)]},
+        "metrics": ["tSystemPresence", "tOrganizationPresence", "tAgentRoutingStatus"],
+    }
+    response = to_dict(with_retry(api.post_analytics_users_aggregates_query)(body=body)) or {}
+    by_user: dict[str, dict[str, dict[str, float]]] = defaultdict(
+        lambda: {"system_presence": {}, "organization_presence": {}, "routing_status": {}}
+    )
+    metric_keys = {
+        "tSystemPresence": "system_presence",
+        "tOrganizationPresence": "organization_presence",
+        "tAgentRoutingStatus": "routing_status",
+    }
+    for result in response.get("results") or []:
+        user_id = (result.get("group") or {}).get("userId")
+        if not user_id:
+            continue
+        for bucket in result.get("data") or []:
+            for metric in bucket.get("metrics") or []:
+                key = metric_keys.get(metric.get("metric"))
+                qualifier = metric.get("qualifier")
+                if not key or not qualifier:
+                    continue
+                seconds = float((metric.get("stats") or {}).get("sum") or 0) / 1000
+                target = by_user[user_id][key]
+                target[qualifier] = target.get(qualifier, 0.0) + seconds
+    return dict(by_user)
+
+
+def _reconcile(
+    details: list[dict],
+    aggregates: dict[str, dict[str, dict[str, float]]],
+    interval_start: Any,
+    interval_end: Any,
+    truncated: bool,
+) -> dict[str, Any]:
+    detail_seconds: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    for user in details:
+        user_id = user.get("userId")
+        if not user_id:
+            continue
+        for session in user.get("primaryPresence") or []:
+            start_raw = session.get("startTime")
+            if not start_raw:
+                continue
+            try:
+                start = max(interval_start, parse_iso(start_raw))
+                end = min(interval_end, parse_iso(session.get("endTime")) if session.get("endTime") else interval_end)
+            except Exception:
+                continue
+            if end <= start:
+                continue
+            qualifier = (session.get("systemPresence") or "").upper()
+            detail_seconds[user_id][qualifier] += (end - start).total_seconds()
+
+    engaged_users = {
+        user_id
+        for user_id, metrics in aggregates.items()
+        if sum(metrics.get("routing_status", {}).values()) > 0
+    }
+    missing_users: list[str] = []
+    mismatches: list[dict[str, Any]] = []
+    max_delta = 0.0
+    for user_id in sorted(engaged_users):
+        expected = aggregates[user_id].get("system_presence", {})
+        actual = detail_seconds.get(user_id, {})
+        if not actual:
+            missing_users.append(user_id)
+            continue
+        for qualifier in set(expected) | set(actual):
+            if qualifier == "OFFLINE":
+                # A presence record that spans the whole query range can start before the
+                # interval and is legitimately absent from details/query. It is irrelevant to
+                # a handled-agent coaching timeline, so validate the active day instead.
+                continue
+            expected_seconds = expected.get(qualifier, 0.0)
+            actual_seconds = actual.get(qualifier, 0.0)
+            delta = abs(expected_seconds - actual_seconds)
+            max_delta = max(max_delta, delta)
+            tolerance = max(_RECONCILIATION_MIN_TOLERANCE_SECONDS, expected_seconds * _RECONCILIATION_FRACTION)
+            if delta > tolerance:
+                mismatches.append(
+                    {
+                        "user_id": user_id,
+                        "system_presence": qualifier,
+                        "expected_seconds": round(expected_seconds, 1),
+                        "detail_seconds": round(actual_seconds, 1),
+                        "delta_seconds": round(delta, 1),
+                    }
+                )
+
+    return {
+        "reconciled": not truncated and not missing_users and not mismatches,
+        "engaged_user_count": len(engaged_users),
+        "reconciled_user_count": len(engaged_users) - len(missing_users),
+        "missing_user_count": len(missing_users),
+        "mismatch_count": len(mismatches),
+        "max_delta_seconds": round(max_delta, 1),
+        "truncated": truncated,
+        # Counts plus bounded examples provide an operational signal without bloating
+        # every snapshot.
+        "mismatch_examples": mismatches[:5],
+    }
+
+
+def fetch_user_details(user_ids: list[str], interval: str, max_pages: int = 50) -> dict[str, Any]:
+    """Fetch user details, falling back to recent query data when the archive lags.
+
+    ``data_complete`` means the returned detail is safe for report use.  The separate
+    ``archive_data_complete`` retains the jobs watermark truth so QueueIQ can keep its
+    delayed repair scheduled and later replace provisional data with the archive.
+    """
+    key = (interval, tuple(sorted(user_ids)), max_pages)
+    now = time.monotonic()
+    with _cache_lock:
+        cached = _cache.get(key)
+        if cached and now - cached[0] < _CACHE_TTL_SECONDS:
+            return copy.deepcopy(cached[1])
+
+    start_raw, end_raw = interval.split("/", 1)
+    interval_start = parse_iso(start_raw)
+    interval_end = parse_iso(end_raw)
+    api = gc.AnalyticsApi(get_api())
+    availability = presence_data_availability(api, interval_end)
+    archive_complete = availability["complete"]
+
+    if archive_complete is True:
+        details, truncated = _async_details(api, user_ids, interval, max_pages)
+        result = {
+            "user_details": details,
+            "truncated": truncated,
+            "data_complete": not truncated,
+            "archive_data_complete": True,
+            "data_provisional": False,
+            "data_source": "analytics_users_details_jobs",
+            "data_available_until": availability["data_available_until"],
+            "data_availability_note": availability["note"],
+            "fallback_validation": None,
+        }
+    else:
+        try:
+            details, truncated, total_hits = _sync_details(api, user_ids, interval, max_pages)
+            aggregates = _qualified_aggregates(api, user_ids, interval)
+            validation = _reconcile(details, aggregates, interval_start, interval_end, truncated)
+            usable_complete = validation["reconciled"]
+            note = (
+                "The archived users/details watermark has not reached the end of this interval. "
+                "QueueIQ used the recent synchronous user-detail query and reconciled active-user "
+                "durations against user aggregates; the archive repair should replace it later."
+                if usable_complete
+                else "The recent synchronous user-detail fallback did not reconcile completely; treat presence totals as partial."
+            )
+            result = {
+                "user_details": details,
+                "truncated": truncated,
+                "data_complete": usable_complete,
+                "archive_data_complete": archive_complete,
+                "data_provisional": usable_complete,
+                "data_source": "analytics_users_details_query_reconciled" if usable_complete else "analytics_users_details_query_unreconciled",
+                "data_available_until": availability["data_available_until"],
+                "data_availability_note": note,
+                "fallback_validation": {**validation, "total_hits": total_hits},
+            }
+        except Exception as exc:
+            logger.warning("users/details synchronous fallback failed; using archive job response: %s", exc)
+            details, truncated = _async_details(api, user_ids, interval, max_pages)
+            result = {
+                "user_details": details,
+                "truncated": truncated,
+                "data_complete": archive_complete is True and not truncated,
+                "archive_data_complete": archive_complete,
+                "data_provisional": False,
+                "data_source": "analytics_users_details_jobs_partial",
+                "data_available_until": availability["data_available_until"],
+                "data_availability_note": availability["note"],
+                "fallback_validation": {"reconciled": False, "error": str(exc)[:300]},
+            }
+
+    with _cache_lock:
+        _cache[key] = (time.monotonic(), copy.deepcopy(result))
+    return result

--- a/src/genesys_mcp/tools/presence.py
+++ b/src/genesys_mcp/tools/presence.py
@@ -1,27 +1,14 @@
-"""Presence tools — agent break/meal/away/etc session-level data via the
-analytics/users/details async-jobs API, but presented as a one-shot tool that
-hides the submit-poll-paginate dance.
-"""
+"""Presence tools — agent break/meal/away/etc session-level analytics data."""
 
 from __future__ import annotations
 
-import logging
-import time
-from datetime import datetime, timedelta, timezone
-from typing import Any
-
-import PureCloudPlatformClientV2 as gc
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from genesys_mcp._availability import presence_data_availability
 from genesys_mcp._intervals import INTERVAL_HELP_STRING
 from genesys_mcp._intervals import default_interval as _default_interval
 from genesys_mcp._intervals import parse_iso as _parse_iso
-from genesys_mcp.client import get_api, to_dict, with_retry
-
-logger = logging.getLogger(__name__)
-
+from genesys_mcp._user_details import fetch_user_details
 
 def register(mcp: FastMCP) -> None:
     @mcp.tool()
@@ -59,9 +46,11 @@ def register(mcp: FastMCP) -> None:
     ) -> dict:
         """Per-user presence sessions (clipped to the interval) for break/meal/away analysis.
 
-        Wraps /api/v2/analytics/users/details/jobs (submit → poll → paginate) into a
-        single call. Returns a flat list per user with start_utc, end_utc, duration_s,
-        and the systemPresence label. Each session is clipped to the requested interval.
+        Uses the authoritative asynchronous archive when it has settled. While that
+        archive is lagging, it can use the recent synchronous user-detail endpoint only
+        after reconciling active-user presence durations against user aggregates.
+        Returns a flat list per user with start_utc, end_utc, duration_s, and the
+        systemPresence label. Each session is clipped to the requested interval.
 
         Common usage:
         - Break/lunch overrun checks: filter to ['BREAK','MEAL'] (the default), then look
@@ -73,12 +62,10 @@ def register(mcp: FastMCP) -> None:
           measure duration reliably).
         - Use the AnalyticsApi job results cursor under the hood; if the cap is hit,
           'truncated': true is set in the response.
-        - Data availability: presence detail settles asynchronously. The response
-          carries 'data_complete' (False when the interval extends past Genesys'
-          settled watermark 'data_available_until'), plus a 'data_availability_note'.
-          When data_complete is False, sessions after the watermark are MISSING —
-          do not treat the last returned session as the agent's logout, and treat
-          per-presence totals as lower bounds.
+        - ``data_complete`` means the returned rows are safe to use. When
+          ``data_provisional`` is true, they came from a reconciled recent-data fallback;
+          ``archive_data_complete`` remains false so consumers can repair from the
+          authoritative archive later.
         """
         if not user_ids:
             raise ValueError("user_ids must contain at least one id.")
@@ -94,107 +81,46 @@ def register(mcp: FastMCP) -> None:
         except Exception as exc:
             raise ValueError(f"Invalid interval {interval!r}: {exc}") from exc
 
-        api = gc.AnalyticsApi(get_api())
-        # Presence detail data settles asynchronously; a window extending past
-        # the availability watermark returns partial with no error. Check it up
-        # front so the response can flag incompleteness rather than imply the
-        # last recorded session was the agent's real logout.
-        availability = presence_data_availability(api, interval_end)
-        body = {
-            "interval": interval,
-            "order": "asc",
-            "userFilters": [
-                {
-                    "type": "or",
-                    "predicates": [
-                        {"type": "dimension", "dimension": "userId",
-                         "operator": "matches", "value": uid}
-                        for uid in user_ids
-                    ],
-                }
-            ],
-        }
-        submit = with_retry(api.post_analytics_users_details_jobs)(body=body)
-        job_id = submit.job_id if hasattr(submit, "job_id") else to_dict(submit).get("jobId")
-        if not job_id:
-            raise RuntimeError(f"users/details/jobs submit returned no jobId: {to_dict(submit)}")
-
-        # Poll until FULFILLED (jobs typically finish within 5–15s)
-        for _ in range(30):
-            status_resp = with_retry(api.get_analytics_users_details_job)(job_id=job_id)
-            state = getattr(status_resp, "state", None) or to_dict(status_resp).get("state")
-            if state == "FULFILLED":
-                break
-            if state in ("FAILED", "CANCELLED", "EXPIRED"):
-                raise RuntimeError(f"job {job_id} terminated in state {state}")
-            time.sleep(1)
-        else:
-            raise RuntimeError(f"job {job_id} did not reach FULFILLED within 30s")
-
-        # Paginate results, collect primaryPresence per user
+        detail_result = fetch_user_details(user_ids, interval, max_pages)
         sessions_by_user: dict[str, list[dict]] = {uid: [] for uid in user_ids}
-        cursor: str | None = None
-        truncated = False
-
-        for page_idx in range(max_pages):
-            kwargs: dict[str, Any] = {"job_id": job_id, "page_size": 1000}
-            if cursor:
-                kwargs["cursor"] = cursor
-            page = with_retry(api.get_analytics_users_details_job_results)(**kwargs)
-            page_dict = to_dict(page) or {}
-            details = page_dict.get("userDetails") or []
-            cursor = page_dict.get("cursor")
-
-            for ud in details:
-                uid = ud.get("userId")
-                if uid not in sessions_by_user:
+        for ud in detail_result["user_details"]:
+            uid = ud.get("userId")
+            if uid not in sessions_by_user:
+                continue
+            for sess in (ud.get("primaryPresence") or []):
+                sp = (sess.get("systemPresence") or "").upper()
+                org_pres_id = sess.get("organizationPresenceId")
+                is_pre_break = (
+                    pre_break_organization_presence_id is not None
+                    and org_pres_id == pre_break_organization_presence_id
+                )
+                label = "PRE_BREAK" if is_pre_break else sp
+                if keep and label not in keep and not is_pre_break:
                     continue
-                for sess in (ud.get("primaryPresence") or []):
-                    sp = (sess.get("systemPresence") or "").upper()
-                    org_pres_id = sess.get("organizationPresenceId")
-                    # v1.3: pre-break detection — BUSY presence with the
-                    # configured org_id gets re-labelled to PRE_BREAK so
-                    # filter logic and downstream consumers can treat it
-                    # as a distinct category.
-                    is_pre_break = (
-                        pre_break_organization_presence_id is not None
-                        and org_pres_id == pre_break_organization_presence_id
-                    )
-                    label = "PRE_BREAK" if is_pre_break else sp
-                    # Standard filter: skip unless either (a) in the keep set
-                    # or (b) it's a configured pre-break session.
-                    if keep and label not in keep and not is_pre_break:
-                        continue
-                    st_raw = sess.get("startTime")
-                    en_raw = sess.get("endTime")
-                    if not st_raw or not en_raw:
-                        continue
-                    try:
-                        st = _parse_iso(st_raw)
-                        en = _parse_iso(en_raw)
-                    except Exception:
-                        continue
-                    # Clip to interval
-                    if en < interval_start or st > interval_end:
-                        continue
-                    st_clip = max(st, interval_start)
-                    en_clip = min(en, interval_end)
-                    dur = (en_clip - st_clip).total_seconds()
-                    if dur <= 0:
-                        continue
-                    sessions_by_user[uid].append({
-                        "system_presence": label,
-                        "organization_presence_id": org_pres_id,
-                        "start_utc": st_clip.isoformat().replace("+00:00", "Z"),
-                        "end_utc": en_clip.isoformat().replace("+00:00", "Z"),
-                        "duration_s": int(dur),
-                        "duration_minutes": round(dur / 60, 1),
-                    })
-
-            if not cursor:
-                break
-        else:
-            truncated = True
+                st_raw = sess.get("startTime")
+                en_raw = sess.get("endTime")
+                if not st_raw or not en_raw:
+                    continue
+                try:
+                    st = _parse_iso(st_raw)
+                    en = _parse_iso(en_raw)
+                except Exception:
+                    continue
+                if en < interval_start or st > interval_end:
+                    continue
+                st_clip = max(st, interval_start)
+                en_clip = min(en, interval_end)
+                dur = (en_clip - st_clip).total_seconds()
+                if dur <= 0:
+                    continue
+                sessions_by_user[uid].append({
+                    "system_presence": label,
+                    "organization_presence_id": org_pres_id,
+                    "start_utc": st_clip.isoformat().replace("+00:00", "Z"),
+                    "end_utc": en_clip.isoformat().replace("+00:00", "Z"),
+                    "duration_s": int(dur),
+                    "duration_minutes": round(dur / 60, 1),
+                })
 
         # Build result with totals per user
         out_users = []
@@ -219,14 +145,13 @@ def register(mcp: FastMCP) -> None:
         return {
             "interval": interval,
             "presence_filter": list(keep) if keep else None,
-            "truncated": truncated,
-            # v1.17: data-availability watermark. `data_complete` is False when
-            # the interval extends past what Genesys has settled — sessions after
-            # `data_available_until` are omitted, so totals and any inferred
-            # logout time are partial. Consumers must not treat the last session
-            # as the agent's real end-of-day when this is False.
-            "data_complete": availability["complete"],
-            "data_available_until": availability["data_available_until"],
-            "data_availability_note": availability["note"],
+            "truncated": detail_result["truncated"],
+            "data_complete": detail_result["data_complete"],
+            "archive_data_complete": detail_result["archive_data_complete"],
+            "data_provisional": detail_result["data_provisional"],
+            "data_source": detail_result["data_source"],
+            "data_available_until": detail_result["data_available_until"],
+            "data_availability_note": detail_result["data_availability_note"],
+            "fallback_validation": detail_result["fallback_validation"],
             "users": out_users,
         }

--- a/src/genesys_mcp/tools/reports.py
+++ b/src/genesys_mcp/tools/reports.py
@@ -22,11 +22,12 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
 from genesys_mcp._aggregates import accumulate_metric_stats
-from genesys_mcp._availability import conversation_data_availability, presence_data_availability
+from genesys_mcp._availability import conversation_data_availability
 from genesys_mcp._intervals import INTERVAL_HELP_STRING
 from genesys_mcp._intervals import default_interval as _default_interval
 from genesys_mcp._intervals import now_utc as _now_utc
 from genesys_mcp._intervals import parse_iso as _parse_iso
+from genesys_mcp._user_details import fetch_user_details
 from genesys_mcp.client import get_api, to_dict, with_retry
 from genesys_mcp.naming import resolver
 
@@ -1001,11 +1002,10 @@ def register(mcp: FastMCP) -> None:
         Returns per-user counts, totals, and per-instance lists so a TL can drill in.
         Sorted by overrun frequency.
 
-        Data availability: presence detail settles asynchronously. The response
-        carries 'data_complete' (False when the interval extends past Genesys'
-        settled watermark 'data_available_until') plus 'data_availability_note'.
-        When False, evening break/meal/away sessions after the watermark are
-        missing, so overrun counts and away totals understate the day.
+        ``data_complete`` means the returned detail is safe to use. When
+        ``data_provisional`` is true, reconciled recent-data detail is being used
+        while Genesys' authoritative archive continues to settle; the separate
+        ``archive_data_complete`` field remains false for later repair.
         """
         # Reuse the presence_sessions tool's data fetching logic by calling the
         # same job pipeline directly here — keeps this tool self-contained.
@@ -1019,100 +1019,62 @@ def register(mcp: FastMCP) -> None:
         except Exception as exc:
             raise ValueError(f"Invalid interval {interval!r}") from exc
 
-        api = gc.AnalyticsApi(get_api())
-        # Presence detail settles asynchronously; a window past the availability
-        # watermark returns partial with no error (an evening break/meal can be
-        # missing entirely). Surface it so overrun counts aren't read as complete.
-        availability = presence_data_availability(api, interval_end)
-        body = {
-            "interval": interval,
-            "order": "asc",
-            "userFilters": [{
-                "type": "or",
-                "predicates": [
-                    {"type": "dimension", "dimension": "userId",
-                     "operator": "matches", "value": uid}
-                    for uid in user_ids
-                ],
-            }],
-        }
-        submit = with_retry(api.post_analytics_users_details_jobs)(body=body)
-        job_id = submit.job_id if hasattr(submit, "job_id") else to_dict(submit).get("jobId")
-
-        for _ in range(30):
-            status = with_retry(api.get_analytics_users_details_job)(job_id=job_id)
-            state = getattr(status, "state", None) or to_dict(status).get("state")
-            if state == "FULFILLED":
-                break
-            if state in ("FAILED", "CANCELLED", "EXPIRED"):
-                raise RuntimeError(f"job {job_id} terminated in state {state}")
-            time.sleep(1)
-
+        detail_result = fetch_user_details(user_ids, interval, max_pages=50)
         sessions_by_user: dict[str, list[dict]] = {uid: [] for uid in user_ids}
-        cursor = None
-        for _ in range(50):
-            kwargs: dict[str, Any] = {"job_id": job_id, "page_size": 1000}
-            if cursor:
-                kwargs["cursor"] = cursor
-            page = with_retry(api.get_analytics_users_details_job_results)(**kwargs)
-            page_dict = to_dict(page) or {}
-            for ud in page_dict.get("userDetails") or []:
-                uid = ud.get("userId")
-                if uid not in sessions_by_user:
+        for ud in detail_result["user_details"]:
+            uid = ud.get("userId")
+            if uid not in sessions_by_user:
+                continue
+            for sess in ud.get("primaryPresence") or []:
+                sp = (sess.get("systemPresence") or "").upper()
+                org_pres_id = sess.get("organizationPresenceId")
+                is_pre_break = (org_pres_id == pre_break_organization_presence_id)
+                is_tracked = sp in ("BREAK", "MEAL", "AWAY") or is_pre_break
+                if not is_tracked:
                     continue
-                for sess in ud.get("primaryPresence") or []:
-                    sp = (sess.get("systemPresence") or "").upper()
-                    org_pres_id = sess.get("organizationPresenceId")
-                    is_pre_break = (org_pres_id == pre_break_organization_presence_id)
-                    is_tracked = sp in ("BREAK", "MEAL", "AWAY") or is_pre_break
-                    if not is_tracked:
-                        continue
-                    if not sess.get("startTime") or not sess.get("endTime"):
-                        continue
-                    try:
-                        st = _parse_iso(sess["startTime"])
-                        en = _parse_iso(sess["endTime"])
-                    except Exception:
-                        continue
-                    if en < interval_start or st > interval_end:
-                        continue
-                    st_clip = max(st, interval_start)
-                    en_clip = min(en, interval_end)
-                    dur_s = (en_clip - st_clip).total_seconds()
-                    if dur_s <= 0:
-                        continue
+                if not sess.get("startTime") or not sess.get("endTime"):
+                    continue
+                try:
+                    st = _parse_iso(sess["startTime"])
+                    en = _parse_iso(sess["endTime"])
+                except Exception:
+                    continue
+                if en < interval_start or st > interval_end:
+                    continue
+                st_clip = max(st, interval_start)
+                en_clip = min(en, interval_end)
+                dur_s = (en_clip - st_clip).total_seconds()
+                if dur_s <= 0:
+                    continue
 
-                    # Categorise — pre-break is BUSY systemPresence with a specific org id,
-                    # so we override the label so downstream logic doesn't lump it under BUSY
-                    if is_pre_break:
-                        category = "PRE_BREAK"
-                        target_min = pre_break_target_min
-                    else:
-                        category = sp
-                        target_min = (
-                            break_target_min if sp == "BREAK"
-                            else meal_target_min if sp == "MEAL"
-                            else 0  # AWAY has no target
-                        )
-                    target_s = target_min * 60
-                    over_target = (
-                        dur_s > (target_s + tolerance_min * 60)
-                        if target_s > 0 else False
+                # Categorise — pre-break is BUSY systemPresence with a specific org id,
+                # so we override the label so downstream logic doesn't lump it under BUSY
+                if is_pre_break:
+                    category = "PRE_BREAK"
+                    target_min = pre_break_target_min
+                else:
+                    category = sp
+                    target_min = (
+                        break_target_min if sp == "BREAK"
+                        else meal_target_min if sp == "MEAL"
+                        else 0  # AWAY has no target
                     )
-                    overrun_min = round((dur_s - target_s) / 60, 1) if (target_s > 0 and dur_s > target_s) else 0.0
+                target_s = target_min * 60
+                over_target = (
+                    dur_s > (target_s + tolerance_min * 60)
+                    if target_s > 0 else False
+                )
+                overrun_min = round((dur_s - target_s) / 60, 1) if (target_s > 0 and dur_s > target_s) else 0.0
 
-                    sessions_by_user[uid].append({
-                        "presence": category,
-                        "start_utc": st_clip.isoformat().replace("+00:00", "Z"),
-                        "duration_s": int(dur_s),
-                        "duration_min": round(dur_s / 60, 1),
-                        "target_min": target_min,
-                        "over_target": over_target,
-                        "overrun_min": overrun_min,
-                    })
-            cursor = page_dict.get("cursor")
-            if not cursor:
-                break
+                sessions_by_user[uid].append({
+                    "presence": category,
+                    "start_utc": st_clip.isoformat().replace("+00:00", "Z"),
+                    "duration_s": int(dur_s),
+                    "duration_min": round(dur_s / 60, 1),
+                    "target_min": target_min,
+                    "over_target": over_target,
+                    "overrun_min": overrun_min,
+                })
 
         # Resolve user names
         names = resolver.user_names(user_ids)
@@ -1185,13 +1147,13 @@ def register(mcp: FastMCP) -> None:
         return {
             "interval": interval,
             "as_of_utc": _now_utc().isoformat().replace("+00:00", "Z"),
-            # v1.17: data-availability watermark. When `data_complete` is False,
-            # presence detail is only settled to `data_available_until`; evening
-            # break/meal sessions after that point are missing, so overrun counts
-            # and away totals understate the day.
-            "data_complete": availability["complete"],
-            "data_available_until": availability["data_available_until"],
-            "data_availability_note": availability["note"],
+            "data_complete": detail_result["data_complete"],
+            "archive_data_complete": detail_result["archive_data_complete"],
+            "data_provisional": detail_result["data_provisional"],
+            "data_source": detail_result["data_source"],
+            "data_available_until": detail_result["data_available_until"],
+            "data_availability_note": detail_result["data_availability_note"],
+            "fallback_validation": detail_result["fallback_validation"],
             "break_target_min": break_target_min,
             "meal_target_min": meal_target_min,
             "pre_break_target_min": pre_break_target_min,

--- a/src/genesys_mcp/tools/utilization.py
+++ b/src/genesys_mcp/tools/utilization.py
@@ -33,14 +33,14 @@ from genesys_mcp.naming import resolver
 logger = logging.getLogger(__name__)
 
 
-# Five canonical routing-status values Genesys reports against
-# tAgentRoutingStatus. Pinned here so the per-user block has stable keys
-# (zero seconds rather than missing key) for downstream table renderers.
+# Stable output keys for downstream renderers. ON_QUEUE/OFF_QUEUE are derived
+# from tSystemPresence; the remaining values are tAgentRoutingStatus qualifiers.
 _ROUTING_STATUSES = (
     "ON_QUEUE",
     "INTERACTING",
     "IDLE",
     "NOT_RESPONDING",
+    "COMMUNICATING",
     "OFF_QUEUE",
 )
 
@@ -49,7 +49,7 @@ def _routing_status_body(user_ids: list[str], interval: str) -> dict:
     """Build the users/aggregates body for routing-status durations."""
     return {
         "interval": interval,
-        "groupBy": ["userId", "routingStatus"],
+        "groupBy": ["userId"],
         "filter": {
             "type": "and",
             "clauses": [
@@ -58,7 +58,7 @@ def _routing_status_body(user_ids: list[str], interval: str) -> dict:
                 ]},
             ],
         },
-        "metrics": ["tAgentRoutingStatus"],
+        "metrics": ["tAgentRoutingStatus", "tSystemPresence"],
     }
 
 
@@ -98,17 +98,27 @@ def _parse_routing_status(resp: dict, user_ids: list[str]) -> dict[str, dict[str
     for grp in resp.get("results") or []:
         group_key = grp.get("group") or {}
         uid = group_key.get("userId")
-        status = (group_key.get("routingStatus") or "").upper()
-        if uid not in by_user or status not in _ROUTING_STATUSES:
+        if uid not in by_user:
             continue
-        sum_ms = 0.0
         for bucket in grp.get("data") or []:
             for m in bucket.get("metrics") or []:
-                if m.get("metric") == "tAgentRoutingStatus":
-                    sum_ms += float((m.get("stats") or {}).get("sum", 0) or 0)
-        # Genesys returns durations in ms; we surface integer seconds for
-        # readability (sub-second precision is noise at the shift scale).
-        by_user[uid][status] += int(sum_ms / 1000)
+                metric = m.get("metric")
+                # Current users/aggregates responses carry the category in the
+                # metric qualifier. Keep the old group dimension as a compatibility
+                # fallback for previously captured fixtures/responses.
+                qualifier = (
+                    m.get("qualifier") or group_key.get("routingStatus") or ""
+                ).upper()
+                sum_seconds = int(float((m.get("stats") or {}).get("sum", 0) or 0) / 1000)
+                if metric == "tAgentRoutingStatus" and qualifier in {
+                    "INTERACTING", "IDLE", "NOT_RESPONDING", "COMMUNICATING",
+                }:
+                    by_user[uid][qualifier] += sum_seconds
+                elif metric == "tSystemPresence":
+                    if qualifier == "ON_QUEUE":
+                        by_user[uid]["ON_QUEUE"] += sum_seconds
+                    else:
+                        by_user[uid]["OFF_QUEUE"] += sum_seconds
     return by_user
 
 
@@ -201,6 +211,7 @@ def _build_user_row(
         "interacting_seconds": routing["INTERACTING"],
         "idle_seconds": routing["IDLE"],
         "not_responding_seconds": routing["NOT_RESPONDING"],
+        "communicating_seconds": routing["COMMUNICATING"],
         "off_queue_seconds": routing["OFF_QUEUE"],
         "voice_answered": voice_answered,
         "message_answered": message_answered,
@@ -252,9 +263,9 @@ def register(mcp: FastMCP) -> None:
 
         v1.6+. Combines two Genesys analytics endpoints in one call:
 
-        - ``/api/v2/analytics/users/aggregates/query`` → routing-status
-          durations (ON_QUEUE / INTERACTING / IDLE / NOT_RESPONDING /
-          OFF_QUEUE seconds per agent)
+        - ``/api/v2/analytics/users/aggregates/query`` → qualified system-
+          presence and routing-status durations (ON_QUEUE / INTERACTING / IDLE /
+          NOT_RESPONDING / COMMUNICATING / OFF_QUEUE seconds per agent)
         - ``/api/v2/analytics/conversations/aggregates/query`` → voice /
           message / callback answered counts + handle time per agent
           (same body as ``agent_performance``, matches the Genesys UI)

--- a/tests/test_agent_utilization.py
+++ b/tests/test_agent_utilization.py
@@ -97,17 +97,23 @@ def _routing_response(per_user_seconds):
     """
     results = []
     for uid, by_status in per_user_seconds.items():
+        metrics = []
         for status, seconds in by_status.items():
-            results.append({
-                "group": {"userId": uid, "routingStatus": status},
-                "data": [{
-                    "interval": _INTERVAL,
-                    "metrics": [{
-                        "metric": "tAgentRoutingStatus",
-                        "stats": {"sum": seconds * 1000, "count": 1},
-                    }],
-                }],
+            metric = (
+                "tSystemPresence"
+                if status in {"ON_QUEUE", "OFF_QUEUE"}
+                else "tAgentRoutingStatus"
+            )
+            qualifier = "AVAILABLE" if status == "OFF_QUEUE" else status
+            metrics.append({
+                "metric": metric,
+                "qualifier": qualifier,
+                "stats": {"sum": seconds * 1000, "count": 1},
             })
+        results.append({
+            "group": {"userId": uid},
+            "data": [{"interval": _INTERVAL, "metrics": metrics}],
+        })
     return {"results": results}
 
 
@@ -164,8 +170,9 @@ class TestRequestShape:
             conv_resp={"results": []},
         )
         body = captured["routing"]
-        assert body["groupBy"] == ["userId", "routingStatus"]
+        assert body["groupBy"] == ["userId"]
         assert "tAgentRoutingStatus" in body["metrics"]
+        assert "tSystemPresence" in body["metrics"]
         assert body["interval"] == _INTERVAL
         f = body["filter"]
         assert f["type"] == "and"

--- a/tests/test_user_details_fallback.py
+++ b/tests/test_user_details_fallback.py
@@ -1,0 +1,186 @@
+"""Recent user-detail fallback and archive-repair contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesys_mcp import _user_details as details
+
+
+INTERVAL = "2026-07-14T00:00:00Z/2026-07-14T01:00:00Z"
+
+
+def _detail(user_id: str = "u1") -> dict:
+    return {
+        "userId": user_id,
+        "primaryPresence": [
+            {
+                "systemPresence": "AVAILABLE",
+                "startTime": "2026-07-14T00:00:00Z",
+                "endTime": "2026-07-14T00:30:00Z",
+            },
+            {
+                "systemPresence": "ON_QUEUE",
+                "startTime": "2026-07-14T00:30:00Z",
+                "endTime": "2026-07-14T01:00:00Z",
+            },
+        ],
+        "routingStatus": [],
+    }
+
+
+def _aggregates(user_id: str = "u1") -> dict:
+    return {
+        "results": [{
+            "group": {"userId": user_id},
+            "data": [{
+                "metrics": [
+                    {
+                        "metric": "tSystemPresence",
+                        "qualifier": "AVAILABLE",
+                        "stats": {"sum": 1_800_000},
+                    },
+                    {
+                        "metric": "tSystemPresence",
+                        "qualifier": "ON_QUEUE",
+                        "stats": {"sum": 1_800_000},
+                    },
+                    {
+                        "metric": "tAgentRoutingStatus",
+                        "qualifier": "INTERACTING",
+                        "stats": {"sum": 600_000},
+                    },
+                ],
+            }],
+        }],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    details.clear_user_details_cache()
+    monkeypatch.setattr(details, "get_api", lambda: object())
+    monkeypatch.setattr(details, "to_dict", lambda value: value)
+    monkeypatch.setattr(details, "with_retry", lambda fn: fn)
+
+
+def test_settled_archive_remains_authoritative(monkeypatch):
+    class Api:
+        def __init__(self, *_args): pass
+
+        def post_analytics_users_details_jobs(self, body):
+            assert body["interval"] == INTERVAL
+            return {"jobId": "job-1"}
+
+        def get_analytics_users_details_job(self, job_id):
+            assert job_id == "job-1"
+            return {"state": "FULFILLED"}
+
+        def get_analytics_users_details_job_results(self, **_kwargs):
+            return {"userDetails": [_detail()]}
+
+    monkeypatch.setattr(details.gc, "AnalyticsApi", Api)
+    monkeypatch.setattr(details, "presence_data_availability", lambda *_args: {
+        "complete": True,
+        "data_available_until": "2026-07-14T02:00:00Z",
+        "note": None,
+    })
+
+    result = details.fetch_user_details(["u1"], INTERVAL)
+
+    assert result["data_complete"] is True
+    assert result["archive_data_complete"] is True
+    assert result["data_provisional"] is False
+    assert result["data_source"] == "analytics_users_details_jobs"
+
+
+def test_lagging_archive_uses_reconciled_sync_detail_and_cache(monkeypatch):
+    calls = {"details": 0, "aggregates": 0}
+
+    class Api:
+        def __init__(self, *_args): pass
+
+        def post_analytics_users_details_query(self, body):
+            calls["details"] += 1
+            assert body["paging"] == {"pageSize": 100, "pageNumber": 1}
+            return {"totalHits": 1, "userDetails": [_detail()]}
+
+        def post_analytics_users_aggregates_query(self, body):
+            calls["aggregates"] += 1
+            assert body["groupBy"] == ["userId"]
+            assert set(body["metrics"]) == {
+                "tSystemPresence", "tOrganizationPresence", "tAgentRoutingStatus",
+            }
+            return _aggregates()
+
+    monkeypatch.setattr(details.gc, "AnalyticsApi", Api)
+    monkeypatch.setattr(details, "presence_data_availability", lambda *_args: {
+        "complete": False,
+        "data_available_until": "2026-07-13T20:00:00Z",
+        "note": "archive lagging",
+    })
+
+    first = details.fetch_user_details(["u1"], INTERVAL)
+    second = details.fetch_user_details(["u1"], INTERVAL)
+
+    assert first == second
+    assert first["data_complete"] is True
+    assert first["archive_data_complete"] is False
+    assert first["data_provisional"] is True
+    assert first["fallback_validation"]["reconciled"] is True
+    assert calls == {"details": 1, "aggregates": 1}
+
+
+def test_missing_engaged_user_keeps_fallback_incomplete(monkeypatch):
+    class Api:
+        def __init__(self, *_args): pass
+
+        def post_analytics_users_details_query(self, body=None, **_kwargs):
+            return {"totalHits": 0, "userDetails": []}
+
+        def post_analytics_users_aggregates_query(self, body=None, **_kwargs):
+            return _aggregates()
+
+    monkeypatch.setattr(details.gc, "AnalyticsApi", Api)
+    monkeypatch.setattr(details, "presence_data_availability", lambda *_args: {
+        "complete": False,
+        "data_available_until": "2026-07-13T20:00:00Z",
+        "note": "archive lagging",
+    })
+
+    result = details.fetch_user_details(["u1"], INTERVAL)
+
+    assert result["data_complete"] is False
+    assert result["data_provisional"] is False
+    assert result["fallback_validation"]["missing_user_count"] == 1
+
+
+def test_sync_failure_falls_back_to_partial_archive(monkeypatch):
+    class Api:
+        def __init__(self, *_args): pass
+
+        def post_analytics_users_details_query(self, **_kwargs):
+            raise RuntimeError("sync unavailable")
+
+        def post_analytics_users_details_jobs(self, **_kwargs):
+            return {"jobId": "job-1"}
+
+        def get_analytics_users_details_job(self, **_kwargs):
+            return {"state": "FULFILLED"}
+
+        def get_analytics_users_details_job_results(self, **_kwargs):
+            return {"userDetails": [_detail()]}
+
+    monkeypatch.setattr(details.gc, "AnalyticsApi", Api)
+    monkeypatch.setattr(details, "presence_data_availability", lambda *_args: {
+        "complete": False,
+        "data_available_until": "2026-07-13T20:00:00Z",
+        "note": "archive lagging",
+    })
+
+    result = details.fetch_user_details(["u1"], INTERVAL)
+
+    assert result["data_complete"] is False
+    assert result["archive_data_complete"] is False
+    assert result["data_source"] == "analytics_users_details_jobs_partial"
+    assert "sync unavailable" in result["fallback_validation"]["error"]


### PR DESCRIPTION
## What changed

- keep the archived users/details job as the authoritative source
- use the synchronous users/details query while the archive watermark lags
- reconcile active-user presence durations against qualified user aggregates before marking fallback data complete
- expose separate usable-data and archive-completeness metadata
- correct agent utilization grouping and qualifier parsing

## Why

Genesys documents that the archived detail watermark can lag the prior reporting day. That was withholding presence, break, timeline, PDF, and card sections even though the recent detail API contained reconcilable data.

## Validation

- 639 pytest tests pass
- live endpoint/schema verification confirmed groupBy userId and metric qualifiers