### PR TITLE
Release genesys-mcp v1.20.1 — pin mcp<2 (fastmcp removed in mcp 2.0.0)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## v1.20.1 — 30 July 2026
+
+**Hotfix: pin `mcp<2`.** The MCP Python SDK released 2.0.0, which removes `mcp.server.fastmcp` — the module every genesys-mcp tool registers through. Environments that install without the lockfile (QueueIQ's image build uses `pip install -e`) resolved 2.0.0 on any rebuild after that release, and the server crashed on import — surfacing in the QueueIQ bridge as `MCP error -32000: Connection closed` on every call, including health checks. The dependency is now `mcp[cli]>=1.8,<2` (the lockfile already pinned 1.27.0, so uv-based dev/test environments were never affected). No behaviour change; rebuild-only.
+
 ## v1.20.0 — 28 July 2026
 
 **`search_conversations_by_attribute` rewritten against the endpoint's real contract.** The participant-attribute search endpoint only supports `conversationId` / `startTime` / `endTime` / `divisionId` as searchable fields — the v1.8–v1.19 request (EXACT on `participantData.<key>` + DATE_RANGE on `segments.start`) used unsupported field paths, so once Genesys enabled the product flag the endpoint rejected **every** call with a generic 400 "Search not supported." (verified live against a real tenant, 2026-07-28).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genesys-mcp"
-version = "1.20.0"
+version = "1.20.1"
 description = "Local stdio MCP server exposing read-only Genesys Cloud access to Claude Code and other MCP clients"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
@@ -8,7 +8,10 @@ classifiers = [
     "License :: Other/Proprietary License",
 ]
 dependencies = [
-    "mcp[cli]>=1.8",
+    # <2: mcp 2.0.0 removed mcp.server.fastmcp, which every tool module
+    # imports. Environments that install without the lockfile (QueueIQ's
+    # `pip install -e` image build) resolve latest and crash on import.
+    "mcp[cli]>=1.8,<2",
     "PureCloudPlatformClientV2>=220",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/tests/test_health_check_upgrades.py
+++ b/tests/test_health_check_upgrades.py
@@ -33,7 +33,7 @@ def test_health_report_exposes_installed_mcp_version(monkeypatch):
 
     report = health_mod.run_health_check()
 
-    assert report["mcp_version"] == "1.20.0"
+    assert report["mcp_version"] == "1.20.1"
 
 
 class TestQueuePatternMatchRate:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,4 +6,4 @@ from genesys_mcp import __version__
 
 
 def test_package_version_is_current_release():
-    assert __version__ == version("genesys-mcp") == "1.20.0"
+    assert __version__ == version("genesys-mcp") == "1.20.1"

--- a/uv.lock
+++ b/uv.lock
@@ -216,7 +216,7 @@ wheels = [
 
 [[package]]
 name = "genesys-mcp"
-version = "1.20.0"
+version = "1.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -235,7 +235,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.8" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.8,<2" },
     { name = "purecloudplatformclientv2", specifier = ">=220" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
## Why

mcp 2.0.0 (PyPI) removes `mcp.server.fastmcp`, which every genesys-mcp tool registers through. downstream consumers' image installs genesys-mcp with `pip install -e` (no lockfile), so the 2026-07-30 rebuild resolved 2.0.0 and the stdio server crashed on import — the bridge logged `MCP error -32000: Connection closed` on every call, including `mcp_health_check`. Verified in the prod container (`ModuleNotFoundError: No module named 'mcp.server.fastmcp'`, venv had mcp 2.0.0) and reproduced locally (`uv run --with mcp` → 2.0.0, fastmcp absent).

## What

- `mcp[cli]>=1.8,<2` dependency cap (lockfile already pinned 1.27.0 — uv environments were never affected)
- Version 1.20.1 + release notes + version-pin tests

## Testing

679 tests passing; lockfile resolution unchanged (mcp 1.27.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
