### PR TITLE
Release genesys-mcp v1.21.0 — transcript session-id fallback

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## v1.21.0 — 5 August 2026
+
+**`get_conversation_transcript` no longer false-404s when recording media isn't materialised.** The tool resolved conversation → session ids solely through `GET /conversations/{id}/recordings`, but Recording objects only carry `sessionId` once their media file is materialised: archived recordings and calls still transcoding come back as stubs **without the key** (verified live — an archived screen recording had `archiveDate`/`archiveMedium` and no `sessionId` at all), and a cold call can return an empty 202 body. When every recording was in such a state, `session_ids` resolved empty and the tool returned `{"status": 404, "message": "no recording sessions found for conversation"}` even though the STA transcript existed and was retrievable by hand via `list_recordings` → `get_transcript_url`. The failure is state-dependent (archive/restore/transcode lifecycle), which is why it appeared and disappeared over a conversation's life.
+
+### The fix
+
+- When the recordings listing yields no session ids, the resolver now falls back to `GET /analytics/conversations/{id}/details`, whose `participants[].sessions[].recording` flag marks recorded sessions independently of media lifecycle. Needs `analytics:conversationDetail:view` — already a required scope.
+- The genuine no-recording 404 is preserved twice over: an unrecorded conversation has no session with `recording: true` (fallback returns nothing → same envelope), and an aged-out recording whose transcript is also gone returns the 404 envelope rather than an empty success (`sessions_processed == 0` guard on the fallback path).
+- Session ids are now de-duplicated (order-preserving) — two recordings of the same session previously fetched the same transcript twice and doubled every utterance.
+- Not the cause, but audited per the report: the `entities` unwrap in the same block only fires for dict responses; this endpoint returns a bare list (verified live), and every other `entities` use in the codebase is against genuinely paginated listing endpoints — no other tool has this bug class.
+- Regression tests pin the endpoint's real response shape (list of camelCase dicts; archived stubs lacking `sessionId`) plus the fallback, genuine-negative, aged-out, and dedup paths. 685 tests.
+
+Output contract unchanged; QueueIQ needs a rebuild only.
+
 ## v1.20.1 — 30 July 2026
 
 **Hotfix: pin `mcp<2`.** The MCP Python SDK released 2.0.0, which removes `mcp.server.fastmcp` — the module every genesys-mcp tool registers through. Environments that install without the lockfile (QueueIQ's image build uses `pip install -e`) resolved 2.0.0 on any rebuild after that release, and the server crashed on import — surfacing in the QueueIQ bridge as `MCP error -32000: Connection closed` on every call, including health checks. The dependency is now `mcp[cli]>=1.8,<2` (the lockfile already pinned 1.27.0, so uv-based dev/test environments were never affected). No behaviour change; rebuild-only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genesys-mcp"
-version = "1.20.1"
+version = "1.21.0"
 description = "Local stdio MCP server exposing read-only Genesys Cloud access to Claude Code and other MCP clients"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }

--- a/src/genesys_mcp/tools/speech_analytics.py
+++ b/src/genesys_mcp/tools/speech_analytics.py
@@ -3,7 +3,9 @@ transcript URLs, and full parsed transcripts for quality reviews + coaching.
 
 Requires the OAuth client to have ``speech-and-text-analytics:readonly``.
 The transcript tool also needs ``recording:recording:view`` (to resolve a
-conversation id → recording session ids before fetching the transcript URL).
+conversation id → recording session ids before fetching the transcript URL)
+and ``analytics:conversationDetail:view`` (fallback session resolution when
+the recording media isn't materialised — archived or still transcoding).
 
 All tools soft-fail on 404 (returning ``{"status": 404, ...}``) so they can
 be used safely in batch loops over conversation lists, where some calls
@@ -162,6 +164,38 @@ def _fetch_transcript_json(url: str) -> dict:
     return resp.json()
 
 
+def _recorded_session_ids_from_analytics(conversation_id: str) -> list[str]:
+    """Resolve recorded session ids via the analytics conversation detail.
+
+    Fallback for when ``get_conversation_recordings`` yields no session ids:
+    Recording objects only carry ``sessionId`` once their media file is
+    materialised — archived recordings and calls still transcoding come back
+    as stubs without the key, and a cold call can return an empty body. The
+    analytics detail flags recorded sessions (``sessions[].recording``)
+    independently of that media lifecycle.
+
+    Returns [] when no session was recorded (the genuine no-recording case)
+    or when the detail record itself 404s (not indexed yet).
+    """
+    conv_api = gc.ConversationsApi(get_api())
+    try:
+        detail_resp = with_retry(conv_api.get_analytics_conversation_details)(
+            conversation_id=conversation_id,
+        )
+    except Exception as exc:
+        if getattr(exc, "status", None) == 404:
+            return []
+        raise
+    detail = to_dict(detail_resp) or {}
+    session_ids: list[str] = []
+    for participant in detail.get("participants") or []:
+        for session in participant.get("sessions") or []:
+            session_id = session.get("sessionId")
+            if session_id and session.get("recording") and session_id not in session_ids:
+                session_ids.append(session_id)
+    return session_ids
+
+
 def fetch_conversation_transcript(
     conversation_id: str,
     *,
@@ -197,7 +231,13 @@ def fetch_conversation_transcript(
     recordings = to_dict(recordings_resp) or []
     if isinstance(recordings, dict):
         recordings = recordings.get("entities") or [recordings]
-    session_ids = [r.get("sessionId") for r in recordings if r.get("sessionId")]
+    session_ids = list(dict.fromkeys(
+        r.get("sessionId") for r in recordings if r.get("sessionId")
+    ))
+    used_analytics_fallback = False
+    if not session_ids:
+        session_ids = _recorded_session_ids_from_analytics(conversation_id)
+        used_analytics_fallback = True
     if not session_ids:
         return soft_fail_envelope(
             kind="recordings",
@@ -252,6 +292,16 @@ def fetch_conversation_transcript(
             participants_seen.setdefault(role, ident)
 
         all_utterances.extend(_build_utterance_list(tj))
+
+    if used_analytics_fallback and sessions_processed == 0:
+        # Analytics says a session was recorded, but no transcript is
+        # retrievable (recording aged out, STA disabled). Keep the soft-fail
+        # contract for batch loops rather than returning an empty success.
+        return soft_fail_envelope(
+            kind="recordings",
+            message="no transcript available for conversation's recorded sessions",
+            conversation_id=conversation_id,
+        )
 
     all_utterances.sort(key=lambda u: (u.get("start_s") is None, u.get("start_s") or 0))
 
@@ -360,10 +410,12 @@ def register(mcp: FastMCP) -> None:
         """Structured, time-aligned transcript for a conversation.
 
         Resolves the conversation id → recording session ids via
-        ``recording:recording:view``, then for each session pulls the
-        STA transcript URL and downloads the JSON. Returns a flat list of
-        utterances attributed to ``customer`` / ``agent`` / ``ivr`` / ``acd``
-        with start time and optional per-utterance sentiment.
+        ``recording:recording:view`` (falling back to the analytics
+        conversation detail when the recordings are archived or still
+        transcoding and so carry no session id yet), then for each session
+        pulls the STA transcript URL and downloads the JSON. Returns a flat
+        list of utterances attributed to ``customer`` / ``agent`` / ``ivr``
+        / ``acd`` with start time and optional per-utterance sentiment.
 
         Useful for:
 

--- a/tests/test_health_check_upgrades.py
+++ b/tests/test_health_check_upgrades.py
@@ -33,7 +33,7 @@ def test_health_report_exposes_installed_mcp_version(monkeypatch):
 
     report = health_mod.run_health_check()
 
-    assert report["mcp_version"] == "1.20.1"
+    assert report["mcp_version"] == "1.21.0"
 
 
 class TestQueuePatternMatchRate:

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -183,8 +183,15 @@ class TestFetchConversationTranscriptEndToEnd:
     """Mock the SDK + HTTP layer; assert the full pipeline composes correctly."""
 
     def _patch_chain(self, monkeypatch, recordings, transcript_json,
-                     transcript_url="https://example.invalid/t.json"):
-        """Patch RecordingApi + SpeechTextAnalyticsApi + httpx in one shot."""
+                     transcript_url="https://example.invalid/t.json",
+                     analytics_sessions=None, transcript_url_404=False):
+        """Patch RecordingApi + SpeechTextAnalyticsApi + ConversationsApi + httpx.
+
+        ``analytics_sessions`` feeds the analytics-details fallback used when
+        the recordings listing yields no session ids (archived / still-
+        transcoding recordings). ``transcript_url_404`` makes every
+        transcript-url lookup soft-404, simulating an aged-out recording.
+        """
         import PureCloudPlatformClientV2 as gc
         from genesys_mcp import client as gen_client
         from genesys_mcp.tools import speech_analytics as sa
@@ -199,12 +206,23 @@ class TestFetchConversationTranscriptEndToEnd:
             def __init__(self, url): self.url = url
             def to_dict(self): return {"url": self.url}
 
+        class Fake404(Exception):
+            status = 404
+
         class FakeStaApi:
             def __init__(self, *args, **kwargs): pass
             def get_speechandtextanalytics_conversation_communication_transcripturl(
                 self, conversation_id, communication_id,
             ):
+                if transcript_url_404:
+                    raise Fake404("transcript url not found")
                 return FakeTranscriptUrlResp(transcript_url)
+
+        class FakeConversationsApi:
+            def __init__(self, *args, **kwargs): pass
+            def get_analytics_conversation_details(self, conversation_id):
+                return {"conversationId": conversation_id,
+                        "participants": [{"sessions": analytics_sessions or []}]}
 
         # Replace the SDK shape converter with an identity-ish that handles
         # both plain dicts and objects with .to_dict().
@@ -220,6 +238,7 @@ class TestFetchConversationTranscriptEndToEnd:
         monkeypatch.setattr(sa, "to_dict", fake_to_dict)
         monkeypatch.setattr(sa.gc, "RecordingApi", FakeRecordingApi)
         monkeypatch.setattr(sa.gc, "SpeechTextAnalyticsApi", FakeStaApi)
+        monkeypatch.setattr(sa.gc, "ConversationsApi", FakeConversationsApi)
         monkeypatch.setattr(gen_client, "_api_client", gc.ApiClient())
 
         class FakeResp:
@@ -299,6 +318,148 @@ class TestFetchConversationTranscriptEndToEnd:
                           transcript_json=_sample_transcript_json())
         with pytest.raises(ValueError, match="must be 'summary' or 'full'"):
             fetch_conversation_transcript("conv-1", mode="abridged")
+
+
+# ─────────────────────── recording-lifecycle false negatives (v1.21) ───────────────────────
+
+def _real_recordings_shape() -> list[dict]:
+    """Shape-accurate ``get_conversation_recordings`` response for a voice call
+    with screen recording, as observed live (ap-southeast-2, 2026-08-05; all
+    values here synthesised).
+
+    Key facts the mocks previously missed:
+
+    - the endpoint returns a **list** (never an ``entities`` envelope);
+    - a materialised recording carries camelCase ``sessionId``;
+    - an archived recording is a stub with ``archiveDate``/``archiveMedium``
+      and **no sessionId key at all** — same for recordings still transcoding.
+    """
+    return [
+        {
+            "id": "rec-audio-1",
+            "conversationId": "conv-1",
+            "sessionId": "session-1",
+            "media": "audio",
+            "fileState": "AVAILABLE",
+            "recordingFileRole": "CUSTOMER_EXPERIENCE",
+            "startTime": "2026-07-28T02:25:03.379Z",
+            "endTime": "2026-07-28T02:29:41.000Z",
+            "annotations": [],
+            "mediaUris": {},
+        },
+        {
+            # Archived stub — sessionId key ABSENT, not merely null.
+            "id": "rec-screen-1",
+            "conversationId": "conv-1",
+            "media": "screen",
+            "fileState": "AVAILABLE",
+            "archiveDate": "2026-08-04T00:00:00.000Z",
+            "archiveMedium": "CLOUDARCHIVE",
+            "startTime": "2026-07-28T02:25:03.379Z",
+            "endTime": "2026-07-28T02:29:41.000Z",
+            "annotations": [],
+            "mediaUris": {},
+            "outputDurationMs": 278000,
+        },
+    ]
+
+
+class TestRecordingLifecycleFalseNegatives:
+    """Session-id resolution must not depend on recording *media* lifecycle.
+
+    Recording objects only carry ``sessionId`` once their media file is
+    materialised; archived/still-transcoding recordings come back as stubs
+    without it, and a cold call can return an empty body outright. The STA
+    transcript exists independently of all that, so the resolver falls back
+    to the analytics conversation detail (``sessions[].recording == True``).
+    """
+
+    _patch_chain = TestFetchConversationTranscriptEndToEnd._patch_chain
+
+    def test_real_response_shape_populates_session_ids(self, monkeypatch):
+        # Regression pin for the live shape: one materialised + one archived
+        # recording → session_ids populated from the materialised one, no 404.
+        from genesys_mcp.tools.speech_analytics import fetch_conversation_transcript
+        self._patch_chain(monkeypatch,
+                          recordings=_real_recordings_shape(),
+                          transcript_json=_sample_transcript_json())
+        out = fetch_conversation_transcript("conv-1")
+        assert "status" not in out
+        assert out["sessions_processed"] == 1
+        assert out["total_utterances"] == 3
+
+    def test_all_recordings_archived_falls_back_to_analytics(self, monkeypatch):
+        # The reported false negative: every recording is an archived stub
+        # (no sessionId anywhere) → resolve sessions via analytics instead.
+        from genesys_mcp.tools.speech_analytics import fetch_conversation_transcript
+        stubs = [{k: v for k, v in r.items() if k != "sessionId"}
+                 for r in _real_recordings_shape()]
+        self._patch_chain(
+            monkeypatch, recordings=stubs,
+            transcript_json=_sample_transcript_json(),
+            analytics_sessions=[
+                {"sessionId": "session-1", "mediaType": "voice", "recording": True},
+                {"sessionId": "session-ivr", "mediaType": "voice"},
+            ])
+        out = fetch_conversation_transcript("conv-1")
+        assert "status" not in out
+        assert out["sessions_processed"] == 1
+        assert out["total_utterances"] == 3
+
+    def test_empty_recordings_body_falls_back(self, monkeypatch):
+        # Cold 202/empty body from the recordings endpoint → same fallback.
+        from genesys_mcp.tools.speech_analytics import fetch_conversation_transcript
+        self._patch_chain(
+            monkeypatch, recordings=None,
+            transcript_json=_sample_transcript_json(),
+            analytics_sessions=[
+                {"sessionId": "session-1", "mediaType": "voice", "recording": True},
+            ])
+        out = fetch_conversation_transcript("conv-1")
+        assert "status" not in out
+        assert out["total_utterances"] == 3
+
+    def test_unrecorded_conversation_still_404s(self, monkeypatch):
+        # Genuine negative: no recordings AND analytics says no session was
+        # recorded → keep the soft-fail envelope for batch loops.
+        from genesys_mcp.tools.speech_analytics import fetch_conversation_transcript
+        self._patch_chain(
+            monkeypatch, recordings=[],
+            transcript_json=_sample_transcript_json(),
+            analytics_sessions=[
+                {"sessionId": "session-1", "mediaType": "voice", "recording": False},
+                {"sessionId": "session-ivr", "mediaType": "voice"},
+            ])
+        out = fetch_conversation_transcript("conv-unrecorded")
+        assert out["status"] == 404
+        assert "no recording sessions" in out["message"]
+
+    def test_aged_out_recording_still_404s(self, monkeypatch):
+        # Analytics remembers the session was recorded, but the transcript is
+        # gone (retention). The fallback path must not turn that into an
+        # empty success — callers rely on the 404 envelope.
+        from genesys_mcp.tools.speech_analytics import fetch_conversation_transcript
+        self._patch_chain(
+            monkeypatch, recordings=[],
+            transcript_json=_sample_transcript_json(),
+            analytics_sessions=[
+                {"sessionId": "session-1", "mediaType": "voice", "recording": True},
+            ],
+            transcript_url_404=True)
+        out = fetch_conversation_transcript("conv-aged-out")
+        assert out["status"] == 404
+
+    def test_duplicate_session_ids_deduped(self, monkeypatch):
+        # Two recordings of the same session (e.g. trunk + consult leg) must
+        # not double every utterance.
+        from genesys_mcp.tools.speech_analytics import fetch_conversation_transcript
+        self._patch_chain(
+            monkeypatch,
+            recordings=[{"sessionId": "session-1"}, {"sessionId": "session-1"}],
+            transcript_json=_sample_transcript_json())
+        out = fetch_conversation_transcript("conv-1")
+        assert out["sessions_processed"] == 1
+        assert out["total_utterances"] == 3
 
 
 # ─────────────────────── token-budget for typical excerpt ───────────────────────

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,4 +6,4 @@ from genesys_mcp import __version__
 
 
 def test_package_version_is_current_release():
-    assert __version__ == version("genesys-mcp") == "1.20.1"
+    assert __version__ == version("genesys-mcp") == "1.21.0"

--- a/uv.lock
+++ b/uv.lock
@@ -216,7 +216,7 @@ wheels = [
 
 [[package]]
 name = "genesys-mcp"
-version = "1.20.1"
+version = "1.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

`get_conversation_transcript` reported a false 404 ("no recording sessions found for conversation") for conversations that demonstrably have recordings and a retrievable STA transcript.

**Root cause (verified live, not the suspected `entities` fallback):** Recording objects only carry `sessionId` once their media file is materialised. Archived recordings come back as stubs with `archiveDate`/`archiveMedium` and *no `sessionId` key at all*; a still-transcoding call can return an empty 202 body. When every recording is in such a state, session resolution came up empty and the tool 404'd — even though the transcript lives in STA independently of media lifecycle. The failure is tenant-state-dependent (archive/restore/transcode), which is why it appeared intermittent.

## Changes

- Fall back to `GET /analytics/conversations/{id}/details` (`sessions[].recording == true`) when the recordings listing yields no session ids. Uses `analytics:conversationDetail:view`, already a required scope.
- De-duplicate session ids (two recordings of one session previously doubled every utterance).
- Preserve the genuine no-recording soft-fail: unrecorded conversations have no `recording: true` session, and the fallback path returns the 404 envelope (not an empty success) when no transcript is retrievable at all.
- Regression tests pin the endpoint's real response shape (bare list, camelCase, archived stubs without `sessionId`) plus fallback / genuine-negative / aged-out / dedup paths — synthetic values only.
- Audited every other `entities` normalisation in the codebase: all target genuinely paginated endpoints; no other tool shares this bug class.

## Verification

- Red-green verified: the three behaviour tests fail without the fix, pass with it. Full suite: **685 passed**.
- Live: with the recordings endpoint forced into the failure state, conversation `80cb17f7-…` resolves session `12a757c5-…` via the fallback and returns all 27 utterances.

Output contract unchanged, tool count unchanged (52) — source-installed deployments need a rebuild only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
