### PR TITLE
Release genesys-mcp v1.22.0 — ownership-checked transcript tool

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## v1.22.0 — 5 August 2026
+
+**New tool: `get_my_conversation_transcript` — ownership-checked transcript access for agent-scoped surfaces.** QueueIQ's agent Teams chat denies all conversation/recording/transcript tools because conversation ids aren't ownership-checked — an agent could paste a colleague's conversation id and read someone else's call. This tool moves the ownership check server-side so agent-facing frontends can safely answer "how did I go on this call?".
+
+- Takes `user_id` + `conversation_id` (+ the same `mode` / `max_utterances` as `get_conversation_transcript`); returns the transcript only when that user was a participant on the conversation, verified against the analytics conversation detail (`participants[].userId`). Frontends force `user_id` to the authenticated agent; a prompt-injected model can't skip a check that lives in the MCP.
+- "Not a participant" and "no such conversation" return **identical** 404 envelopes (`kind: "conversation"`), so conversation ids can't be probed for existence.
+- Output contract on success is identical to `get_conversation_transcript`, including the v1.21.0 archived/transcoding fallback.
+- The unscoped `get_conversation_transcript` is unchanged — direct MCP users (e.g. an admin in Claude Code) keep full access to any conversation their OAuth scopes allow. Verified live: the conversation's real agent gets the transcript; any other user id gets the soft-fail envelope.
+- Scopes: uses `analytics:conversationDetail:view` + the transcript tool's existing scopes — no OAuth changes.
+
+Tool count 52 → **53** — QueueIQ needs a whitelist sync **and** rebuild (add the tool to its MCP tool list and, for the agent chat, to `AGENT_FORCED_USER_ID_TOOLS`). 689 tests.
+
 ## v1.21.0 — 5 August 2026
 
 **`get_conversation_transcript` no longer false-404s when recording media isn't materialised.** The tool resolved conversation → session ids solely through `GET /conversations/{id}/recordings`, but Recording objects only carry `sessionId` once their media file is materialised: archived recordings and calls still transcoding come back as stubs **without the key** (verified live — an archived screen recording had `archiveDate`/`archiveMedium` and no `sessionId` at all), and a cold call can return an empty 202 body. When every recording was in such a state, `session_ids` resolved empty and the tool returned `{"status": 404, "message": "no recording sessions found for conversation"}` even though the STA transcript existed and was retrievable by hand via `list_recordings` → `get_transcript_url`. The failure is state-dependent (archive/restore/transcode lifecycle), which is why it appeared and disappeared over a conversation's life.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genesys-mcp"
-version = "1.21.0"
+version = "1.22.0"
 description = "Local stdio MCP server exposing read-only Genesys Cloud access to Claude Code and other MCP clients"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }

--- a/src/genesys_mcp/tools/speech_analytics.py
+++ b/src/genesys_mcp/tools/speech_analytics.py
@@ -330,6 +330,53 @@ def fetch_conversation_transcript(
     }
 
 
+def fetch_conversation_transcript_for_user(
+    user_id: str,
+    conversation_id: str,
+    *,
+    mode: str = "summary",
+    max_utterances: int = 200,
+) -> dict:
+    """Ownership-checked variant of :func:`fetch_conversation_transcript`.
+
+    Built for agent-scoped callers (QueueIQ's agent Teams chat): the caller
+    supplies a ``user_id`` that an upstream guard pins to the asking agent,
+    and the transcript is returned only when that user was a participant on
+    the conversation (per the analytics conversation detail). This keeps the
+    ownership check server-side, where a prompt-injected model can't skip it.
+
+    A non-participant and a nonexistent conversation return the SAME
+    envelope on purpose — distinct errors would let a caller probe which
+    conversation ids exist.
+    """
+    denied = soft_fail_envelope(
+        kind="conversation",
+        message="conversation not found for user",
+        conversation_id=conversation_id,
+        user_id=user_id,
+    )
+    conv_api = gc.ConversationsApi(get_api())
+    try:
+        detail_resp = with_retry(conv_api.get_analytics_conversation_details)(
+            conversation_id=conversation_id,
+        )
+    except Exception as exc:
+        if getattr(exc, "status", None) == 404:
+            return denied
+        raise
+    detail = to_dict(detail_resp) or {}
+    participant_user_ids = {
+        p.get("userId")
+        for p in detail.get("participants") or []
+        if p.get("userId")
+    }
+    if user_id not in participant_user_ids:
+        return denied
+    return fetch_conversation_transcript(
+        conversation_id, mode=mode, max_utterances=max_utterances,
+    )
+
+
 def register(mcp: FastMCP) -> None:
     @mcp.tool()
     def get_conversation_summary(
@@ -430,6 +477,53 @@ def register(mcp: FastMCP) -> None:
         """
         return fetch_conversation_transcript(
             conversation_id, mode=mode, max_utterances=max_utterances,
+        )
+
+    @mcp.tool()
+    def get_my_conversation_transcript(
+        user_id: str = Field(
+            description=(
+                "User id the transcript access is scoped to. The transcript "
+                "is returned only if this user was a participant on the "
+                "conversation. Agent-facing frontends should force this to "
+                "the authenticated agent's id — never model-supplied."
+            ),
+        ),
+        conversation_id: str = Field(description="Conversation id."),
+        mode: str = Field(
+            default="summary",
+            description=(
+                "Response shape — same contract as get_conversation_transcript: "
+                "'summary' (default) returns {speaker, start_s, text}; 'full' "
+                "adds per-utterance sentiment and sentiment_label."
+            ),
+        ),
+        max_utterances: int = Field(
+            default=200, ge=10, le=2000,
+            description=(
+                "Cap on returned utterances — same contract as "
+                "get_conversation_transcript (`truncated_at` / "
+                "`total_utterances_dropped` on overflow)."
+            ),
+        ),
+    ) -> dict:
+        """Ownership-checked transcript for agent-scoped callers.
+
+        Same output as ``get_conversation_transcript``, but the transcript is
+        returned only when ``user_id`` was a participant on the conversation
+        (verified server-side against the analytics conversation detail).
+        Built for agent-facing surfaces (e.g. QueueIQ's agent Teams chat)
+        where a scope guard pins ``user_id`` to the asking agent, so agents
+        can ask "how did I go on this call?" without being able to read
+        anyone else's conversations.
+
+        Soft-fails with the same 404 envelope for "not a participant" and
+        "no such conversation" — deliberately indistinguishable, so
+        conversation ids can't be probed for existence. Also soft-fails on
+        missing recordings/transcripts like the unscoped tool.
+        """
+        return fetch_conversation_transcript_for_user(
+            user_id, conversation_id, mode=mode, max_utterances=max_utterances,
         )
 
     @mcp.tool()

--- a/tests/test_health_check_upgrades.py
+++ b/tests/test_health_check_upgrades.py
@@ -33,7 +33,7 @@ def test_health_report_exposes_installed_mcp_version(monkeypatch):
 
     report = health_mod.run_health_check()
 
-    assert report["mcp_version"] == "1.21.0"
+    assert report["mcp_version"] == "1.22.0"
 
 
 class TestQueuePatternMatchRate:

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -184,13 +184,17 @@ class TestFetchConversationTranscriptEndToEnd:
 
     def _patch_chain(self, monkeypatch, recordings, transcript_json,
                      transcript_url="https://example.invalid/t.json",
-                     analytics_sessions=None, transcript_url_404=False):
+                     analytics_sessions=None, transcript_url_404=False,
+                     analytics_participants=None, analytics_details_404=False):
         """Patch RecordingApi + SpeechTextAnalyticsApi + ConversationsApi + httpx.
 
         ``analytics_sessions`` feeds the analytics-details fallback used when
         the recordings listing yields no session ids (archived / still-
         transcoding recordings). ``transcript_url_404`` makes every
         transcript-url lookup soft-404, simulating an aged-out recording.
+        ``analytics_participants`` overrides the detail participants wholesale
+        (for ownership checks that read ``userId``); ``analytics_details_404``
+        soft-404s the detail lookup (conversation doesn't exist / not indexed).
         """
         import PureCloudPlatformClientV2 as gc
         from genesys_mcp import client as gen_client
@@ -221,8 +225,14 @@ class TestFetchConversationTranscriptEndToEnd:
         class FakeConversationsApi:
             def __init__(self, *args, **kwargs): pass
             def get_analytics_conversation_details(self, conversation_id):
+                if analytics_details_404:
+                    raise Fake404("conversation details not found")
+                if analytics_participants is not None:
+                    participants = analytics_participants
+                else:
+                    participants = [{"sessions": analytics_sessions or []}]
                 return {"conversationId": conversation_id,
-                        "participants": [{"sessions": analytics_sessions or []}]}
+                        "participants": participants}
 
         # Replace the SDK shape converter with an identity-ish that handles
         # both plain dicts and objects with .to_dict().
@@ -460,6 +470,99 @@ class TestRecordingLifecycleFalseNegatives:
         out = fetch_conversation_transcript("conv-1")
         assert out["sessions_processed"] == 1
         assert out["total_utterances"] == 3
+
+
+# ─────────────────────── ownership-checked transcript (v1.22) ───────────────────────
+
+class TestFetchConversationTranscriptForUser:
+    """`fetch_conversation_transcript_for_user` — the agent-scoped variant.
+
+    Built for QueueIQ's agent Teams chat: the caller supplies a user_id that
+    an upstream guard forces to the asking agent, and the transcript is
+    returned only when that user was a participant on the conversation. A
+    non-participant and a nonexistent conversation must produce IDENTICAL
+    envelopes so conversation ids can't be probed for existence.
+    """
+
+    _patch_chain = TestFetchConversationTranscriptEndToEnd._patch_chain
+
+    def _participants(self):
+        return [
+            {"purpose": "customer",
+             "sessions": [{"sessionId": "session-1", "mediaType": "voice",
+                           "recording": True}]},
+            {"purpose": "agent", "userId": "agent-1",
+             "sessions": [{"sessionId": "session-agent", "mediaType": "voice"}]},
+        ]
+
+    def test_participant_gets_transcript(self, monkeypatch):
+        from genesys_mcp.tools.speech_analytics import (
+            fetch_conversation_transcript_for_user,
+        )
+        self._patch_chain(monkeypatch,
+                          recordings=[{"sessionId": "session-1"}],
+                          transcript_json=_sample_transcript_json(),
+                          analytics_participants=self._participants())
+        out = fetch_conversation_transcript_for_user("agent-1", "conv-1")
+        assert "status" not in out
+        assert out["total_utterances"] == 3
+        assert out["conversation_id"] == "conv-1"
+
+    def test_non_participant_gets_404_envelope(self, monkeypatch):
+        from genesys_mcp.tools.speech_analytics import (
+            fetch_conversation_transcript_for_user,
+        )
+        self._patch_chain(monkeypatch,
+                          recordings=[{"sessionId": "session-1"}],
+                          transcript_json=_sample_transcript_json(),
+                          analytics_participants=self._participants())
+        out = fetch_conversation_transcript_for_user("someone-else", "conv-1")
+        assert out["status"] == 404
+        assert out["user_id"] == "someone-else"
+        assert out["conversation_id"] == "conv-1"
+
+    def test_nonexistent_conversation_envelope_identical_to_non_participant(
+        self, monkeypatch,
+    ):
+        # Anti-enumeration: "not yours" and "doesn't exist" must be
+        # indistinguishable, or an agent could probe which ids are real.
+        from genesys_mcp.tools.speech_analytics import (
+            fetch_conversation_transcript_for_user,
+        )
+        self._patch_chain(monkeypatch,
+                          recordings=[{"sessionId": "session-1"}],
+                          transcript_json=_sample_transcript_json(),
+                          analytics_participants=self._participants())
+        not_yours = fetch_conversation_transcript_for_user("someone-else", "conv-1")
+
+        self._patch_chain(monkeypatch,
+                          recordings=[{"sessionId": "session-1"}],
+                          transcript_json=_sample_transcript_json(),
+                          analytics_details_404=True)
+        missing = fetch_conversation_transcript_for_user("someone-else", "conv-1")
+
+        assert not_yours == missing
+
+    def test_participant_mode_and_cap_pass_through(self, monkeypatch):
+        from genesys_mcp.tools.speech_analytics import (
+            fetch_conversation_transcript_for_user,
+        )
+        big = _sample_transcript_json()
+        big["transcripts"][0]["phrases"] = [
+            {"text": f"utterance {i}", "startTimeMs": i * 1000,
+             "participantPurpose": "external" if i % 2 else "internal"}
+            for i in range(50)
+        ]
+        big["transcripts"][0]["analytics"] = {"sentiment": []}
+        self._patch_chain(monkeypatch,
+                          recordings=[{"sessionId": "session-1"}],
+                          transcript_json=big,
+                          analytics_participants=self._participants())
+        out = fetch_conversation_transcript_for_user(
+            "agent-1", "conv-1", mode="full", max_utterances=10,
+        )
+        assert out["truncated_at"] == 10
+        assert len(out["utterances"]) == 10
 
 
 # ─────────────────────── token-budget for typical excerpt ───────────────────────

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,4 +6,4 @@ from genesys_mcp import __version__
 
 
 def test_package_version_is_current_release():
-    assert __version__ == version("genesys-mcp") == "1.21.0"
+    assert __version__ == version("genesys-mcp") == "1.22.0"

--- a/uv.lock
+++ b/uv.lock
@@ -216,7 +216,7 @@ wheels = [
 
 [[package]]
 name = "genesys-mcp"
-version = "1.21.0"
+version = "1.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Adds `get_my_conversation_transcript(user_id, conversation_id, mode, max_utterances)` — an ownership-checked variant of `get_conversation_transcript` for agent-scoped surfaces.

Agent-scoped chat frontends deny the unscoped conversation/recording/transcript tools because conversation ids aren't ownership-checked. This tool moves the check server-side: the transcript is returned only when `user_id` was a participant on the conversation, verified against the analytics conversation detail (`participants[].userId`). Agent frontends force `user_id` to the authenticated agent, so a prompt-injected model can't skip the check.

## Design points

- **Anti-enumeration:** "not a participant" and "no such conversation" return byte-identical 404 envelopes (`kind: "conversation"`), so conversation ids can't be probed for existence.
- **Additive:** the unscoped `get_conversation_transcript` is unchanged — direct MCP users (e.g. admins in Claude Code) keep full access per their OAuth scopes.
- **Same success contract** as the unscoped tool, including the v1.21.0 archived/transcoding session fallback.
- **No OAuth changes:** uses `analytics:conversationDetail:view`, already a required scope.

## Verification

- TDD red-green: four new tests (participant success, non-participant denial, envelope-identity anti-enumeration, mode/cap pass-through) failed before implementation, pass after. Full suite: **689 passed**.
- Live: the conversation's real agent receives all 27 utterances; a bogus user id and a nonexistent conversation id produce identical soft-fail envelopes.

Tool count 52 → **53**: frontends that pin the tool surface need a whitelist sync plus rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
